### PR TITLE
feat(users): implement phase 4 — user profile and member management

### DIFF
--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -378,3 +378,15 @@
 - **Arquivos modificados:**
   - `formix-frontend/src/app/(app)/settings/members/page.tsx`
 - **Verificação:** typecheck OK, build OK
+
+### features/start US-021: Remover Membro — Backend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.ts`
+  - `formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.spec.ts`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts`
+  - `formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts`
+  - `formix-backend/src/modules/organizations/organizations.module.ts`
+- **Verificação:** typecheck OK, testes OK (5 unit + 9 integration total)

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -326,3 +326,19 @@
   - `formix-frontend/src/app/not-found.tsx`
   - `formix-frontend/src/app/not-found.module.css`
 - **Verificação final:** typecheck OK, build OK
+
+### features/start US-017: Perfil do Usuário — Backend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-backend/src/modules/users/domain/usecases/get-profile.usecase.ts`
+  - `formix-backend/src/modules/users/domain/usecases/get-profile.usecase.spec.ts`
+  - `formix-backend/src/modules/users/domain/usecases/update-profile.usecase.ts`
+  - `formix-backend/src/modules/users/domain/usecases/update-profile.usecase.spec.ts`
+  - `formix-backend/src/modules/users/infra/controllers/get-profile-response.dto.ts`
+  - `formix-backend/src/modules/users/infra/controllers/update-profile.dto.ts`
+  - `formix-backend/src/modules/users/infra/controllers/users.controller.ts`
+  - `formix-backend/src/modules/users/infra/controllers/users.controller.test.ts`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/users/users.module.ts`
+- **Verificação:** typecheck OK, testes OK (8 unit + 6 integration)

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -390,3 +390,14 @@
   - `formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts`
   - `formix-backend/src/modules/organizations/organizations.module.ts`
 - **Verificação:** typecheck OK, testes OK (5 unit + 9 integration total)
+
+### features/start US-022: Remover Membro — Frontend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-frontend/src/modules/MembersTable/RemoveMemberModal.tsx`
+  - `formix-frontend/src/modules/MembersTable/RemoveMemberModal.module.css`
+- **Arquivos modificados:**
+  - `formix-frontend/src/services/organizations/organizations.service.ts`
+  - `formix-frontend/src/app/(app)/settings/members/page.tsx`
+- **Verificação:** typecheck OK, build OK

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -352,3 +352,16 @@
 - **Arquivos modificados:**
   - `formix-frontend/src/app/(app)/settings/profile/page.tsx`
 - **Verificação:** typecheck OK, build OK
+
+### features/start US-019: Listar Membros da Organização — Backend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.ts`
+  - `formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.spec.ts`
+  - `formix-backend/src/modules/organizations/infra/controllers/list-members-response.dto.ts`
+  - `formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts`
+  - `formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/organizations/organizations.module.ts`
+- **Verificação:** typecheck OK, testes OK (3 unit + 4 integration)

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -342,3 +342,13 @@
 - **Arquivos modificados:**
   - `formix-backend/src/modules/users/users.module.ts`
 - **Verificação:** typecheck OK, testes OK (8 unit + 6 integration)
+
+### features/start US-018: Perfil do Usuário — Frontend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-frontend/src/services/users/users.types.ts`
+  - `formix-frontend/src/services/users/users.service.ts`
+- **Arquivos modificados:**
+  - `formix-frontend/src/app/(app)/settings/profile/page.tsx`
+- **Verificação:** typecheck OK, build OK

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -365,3 +365,16 @@
 - **Arquivos modificados:**
   - `formix-backend/src/modules/organizations/organizations.module.ts`
 - **Verificação:** typecheck OK, testes OK (3 unit + 4 integration)
+
+### features/start US-020: Listar Membros — Frontend
+- **Status:** Concluído
+- **Data:** 2026-03-18
+- **Arquivos criados:**
+  - `formix-frontend/src/services/organizations/organizations.types.ts`
+  - `formix-frontend/src/services/organizations/organizations.service.ts`
+  - `formix-frontend/src/modules/MembersTable/MembersTable.tsx`
+  - `formix-frontend/src/modules/MembersTable/MembersTable.module.css`
+  - `formix-frontend/src/modules/MembersTable/RoleBadge.tsx`
+- **Arquivos modificados:**
+  - `formix-frontend/src/app/(app)/settings/members/page.tsx`
+- **Verificação:** typecheck OK, build OK

--- a/formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.spec.ts
+++ b/formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.spec.ts
@@ -1,0 +1,127 @@
+import { ListMembersUseCase } from './list-members.usecase';
+import { IOrganizationRepository } from '@modules/organizations/domain/repositories/organization.repository';
+import { IUserRepository } from '@modules/users/domain/repositories/user.repository';
+import { Organization } from '@modules/organizations/domain/aggregate/organization.aggregate';
+import { OrganizationId } from '@modules/organizations/domain/aggregate/value-objects/organization-id.vo';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Slug } from '@modules/organizations/domain/aggregate/value-objects/slug.vo';
+import { MembershipEntity } from '@modules/organizations/domain/aggregate/entities/membership.entity';
+import { MembershipId } from '@modules/organizations/domain/aggregate/value-objects/membership-id.vo';
+import { MemberRole } from '@modules/organizations/domain/aggregate/value-objects/member-role.enum';
+import { User } from '@modules/users/domain/aggregate/user.aggregate';
+import { Email } from '@shared/value-objects/email.vo';
+import { Password } from '@shared/value-objects/password.vo';
+import { Output } from '@shared/output';
+
+function makeOrg(memberUserIds: Array<{ userId: UserId; role: MemberRole }>): Organization {
+  const orgId = OrganizationId.create();
+  const members = memberUserIds.map(({ userId, role }) =>
+    MembershipEntity.reconstitute({
+      id: MembershipId.create(),
+      userId,
+      role,
+      createdAt: new Date('2026-01-15T10:00:00.000Z'),
+    }),
+  );
+  return Organization.reconstitute({
+    id: orgId,
+    name: 'Test Org',
+    slug: Slug.create('test-org'),
+    members,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+function makeUser(userId: UserId, name: string, email: string): User {
+  return User.reconstitute({
+    id: userId,
+    name,
+    email: Email.create(email),
+    passwordHash: Password.fromHash('$2b$10$hash'),
+    emailConfirmed: true,
+    emailConfirmationToken: null,
+    refreshTokens: [],
+    passwordResetToken: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+describe('ListMembersUseCase', () => {
+  let useCase: ListMembersUseCase;
+  let orgRepo: jest.Mocked<IOrganizationRepository>;
+  let userRepo: jest.Mocked<IUserRepository>;
+
+  beforeEach(() => {
+    orgRepo = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findBySlug: jest.fn(),
+      findByMemberId: jest.fn(),
+      existsBySlug: jest.fn(),
+    };
+    userRepo = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findByEmailConfirmationTokenHash: jest.fn(),
+      findByRefreshTokenHash: jest.fn(),
+      findByPasswordResetTokenHash: jest.fn(),
+      exists: jest.fn(),
+    };
+    useCase = new ListMembersUseCase(orgRepo, userRepo);
+  });
+
+  it('should return members with user data', async () => {
+    const userId1 = UserId.create();
+    const userId2 = UserId.create();
+    const org = makeOrg([
+      { userId: userId1, role: MemberRole.ADMIN },
+      { userId: userId2, role: MemberRole.MEMBER },
+    ]);
+    const user1 = makeUser(userId1, 'Alice', 'alice@example.com');
+    const user2 = makeUser(userId2, 'Bob', 'bob@example.com');
+
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+    userRepo.findById
+      .mockResolvedValueOnce(Output.ok(user1))
+      .mockResolvedValueOnce(Output.ok(user2));
+
+    const result = await useCase.execute({ organizationId: org.id.getValue() });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value.members).toHaveLength(2);
+    expect(result.value.members[0]).toMatchObject({
+      userId: userId1.getValue(),
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: MemberRole.ADMIN,
+    });
+    expect(result.value.members[0].joinedAt).toBeDefined();
+    expect(result.value.members[0]).not.toHaveProperty('passwordHash');
+  });
+
+  it('should return Output.fail when organization not found', async () => {
+    orgRepo.findById.mockResolvedValue(Output.fail('Organization not found'));
+
+    const result = await useCase.execute({ organizationId: OrganizationId.create().getValue() });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Organization not found');
+  });
+
+  it('should not return members from another organization', async () => {
+    const userId = UserId.create();
+    const org = makeOrg([{ userId, role: MemberRole.ADMIN }]);
+    const user = makeUser(userId, 'Alice', 'alice@example.com');
+
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+
+    const result = await useCase.execute({ organizationId: org.id.getValue() });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value.members).toHaveLength(1);
+  });
+});

--- a/formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.ts
+++ b/formix-backend/src/modules/organizations/domain/usecases/list-members.usecase.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from '@modules/organizations/domain/repositories/organization.repository';
+import { IUserRepository, USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
+import { OrganizationId } from '@modules/organizations/domain/aggregate/value-objects/organization-id.vo';
+import { Output } from '@shared/output';
+
+export interface ListMembersInput {
+  organizationId: string;
+}
+
+export interface MemberDto {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  joinedAt: Date;
+}
+
+export interface ListMembersOutput {
+  members: MemberDto[];
+}
+
+@Injectable()
+export class ListMembersUseCase {
+  constructor(
+    @Inject(ORGANIZATION_REPOSITORY) private readonly orgRepo: IOrganizationRepository,
+    @Inject(USER_REPOSITORY) private readonly userRepo: IUserRepository,
+  ) {}
+
+  async execute(input: ListMembersInput): Promise<Output<ListMembersOutput>> {
+    const orgResult = await this.orgRepo.findById(OrganizationId.from(input.organizationId));
+    if (orgResult.isFailure) return Output.fail(orgResult.errorMessage);
+
+    const org = orgResult.value;
+    const members: MemberDto[] = [];
+
+    for (const membership of org.members) {
+      const userResult = await this.userRepo.findById(membership.userId);
+      if (userResult.isFailure) continue;
+
+      const user = userResult.value;
+      members.push({
+        userId: membership.userId.getValue(),
+        name: user.name,
+        email: user.email.getValue(),
+        role: membership.role,
+        joinedAt: membership.createdAt,
+      });
+    }
+
+    return Output.ok({ members });
+  }
+}

--- a/formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.spec.ts
+++ b/formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.spec.ts
@@ -1,0 +1,136 @@
+import { RemoveMemberUseCase } from './remove-member.usecase';
+import { IOrganizationRepository } from '@modules/organizations/domain/repositories/organization.repository';
+import { Organization } from '@modules/organizations/domain/aggregate/organization.aggregate';
+import { OrganizationId } from '@modules/organizations/domain/aggregate/value-objects/organization-id.vo';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Slug } from '@modules/organizations/domain/aggregate/value-objects/slug.vo';
+import { MembershipEntity } from '@modules/organizations/domain/aggregate/entities/membership.entity';
+import { MembershipId } from '@modules/organizations/domain/aggregate/value-objects/membership-id.vo';
+import { MemberRole } from '@modules/organizations/domain/aggregate/value-objects/member-role.enum';
+import { Output } from '@shared/output';
+
+function makeOrg(admin: UserId, member?: UserId): Organization {
+  const members: MembershipEntity[] = [
+    MembershipEntity.reconstitute({
+      id: MembershipId.create(),
+      userId: admin,
+      role: MemberRole.ADMIN,
+      createdAt: new Date(),
+    }),
+  ];
+  if (member) {
+    members.push(
+      MembershipEntity.reconstitute({
+        id: MembershipId.create(),
+        userId: member,
+        role: MemberRole.MEMBER,
+        createdAt: new Date(),
+      }),
+    );
+  }
+  return Organization.reconstitute({
+    id: OrganizationId.create(),
+    name: 'Test Org',
+    slug: Slug.create('test-org'),
+    members,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+describe('RemoveMemberUseCase', () => {
+  let useCase: RemoveMemberUseCase;
+  let orgRepo: jest.Mocked<IOrganizationRepository>;
+
+  beforeEach(() => {
+    orgRepo = {
+      save: jest.fn(),
+      findById: jest.fn(),
+      findBySlug: jest.fn(),
+      findByMemberId: jest.fn(),
+      existsBySlug: jest.fn(),
+    };
+    useCase = new RemoveMemberUseCase(orgRepo);
+  });
+
+  it('should remove a member when requested by admin', async () => {
+    const adminId = UserId.create();
+    const memberId = UserId.create();
+    const org = makeOrg(adminId, memberId);
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+    orgRepo.save.mockResolvedValue();
+
+    const result = await useCase.execute({
+      organizationId: org.id.getValue(),
+      requestingUserId: adminId.getValue(),
+      targetUserId: memberId.getValue(),
+    });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value).toEqual({ removed: true });
+    expect(orgRepo.save).toHaveBeenCalled();
+  });
+
+  it('should fail when requesting user is not admin', async () => {
+    const adminId = UserId.create();
+    const memberId = UserId.create();
+    const org = makeOrg(adminId, memberId);
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+
+    const result = await useCase.execute({
+      organizationId: org.id.getValue(),
+      requestingUserId: memberId.getValue(),
+      targetUserId: adminId.getValue(),
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Only admins can remove members');
+    expect(orgRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('should fail when admin tries to remove themselves as the last admin', async () => {
+    const adminId = UserId.create();
+    const org = makeOrg(adminId);
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+
+    const result = await useCase.execute({
+      organizationId: org.id.getValue(),
+      requestingUserId: adminId.getValue(),
+      targetUserId: adminId.getValue(),
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Cannot remove the last admin of an organization');
+    expect(orgRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('should fail when target member not found in organization', async () => {
+    const adminId = UserId.create();
+    const nonMemberId = UserId.create();
+    const org = makeOrg(adminId);
+    orgRepo.findById.mockResolvedValue(Output.ok(org));
+
+    const result = await useCase.execute({
+      organizationId: org.id.getValue(),
+      requestingUserId: adminId.getValue(),
+      targetUserId: nonMemberId.getValue(),
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Member not found in this organization');
+    expect(orgRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('should return Output.fail when organization not found', async () => {
+    orgRepo.findById.mockResolvedValue(Output.fail('Organization not found'));
+
+    const result = await useCase.execute({
+      organizationId: OrganizationId.create().getValue(),
+      requestingUserId: UserId.create().getValue(),
+      targetUserId: UserId.create().getValue(),
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Organization not found');
+  });
+});

--- a/formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.ts
+++ b/formix-backend/src/modules/organizations/domain/usecases/remove-member.usecase.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from '@modules/organizations/domain/repositories/organization.repository';
+import { OrganizationId } from '@modules/organizations/domain/aggregate/value-objects/organization-id.vo';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { MemberRole } from '@modules/organizations/domain/aggregate/value-objects/member-role.enum';
+import { Output } from '@shared/output';
+
+export interface RemoveMemberInput {
+  organizationId: string;
+  requestingUserId: string;
+  targetUserId: string;
+}
+
+@Injectable()
+export class RemoveMemberUseCase {
+  constructor(
+    @Inject(ORGANIZATION_REPOSITORY) private readonly orgRepo: IOrganizationRepository,
+  ) {}
+
+  async execute(input: RemoveMemberInput): Promise<Output<{ removed: true }>> {
+    const orgResult = await this.orgRepo.findById(OrganizationId.from(input.organizationId));
+    if (orgResult.isFailure) return Output.fail(orgResult.errorMessage);
+
+    const org = orgResult.value;
+    const requestingId = UserId.from(input.requestingUserId);
+    const targetId = UserId.from(input.targetUserId);
+
+    const requester = org.findMemberByUserId(requestingId);
+    if (!requester || requester.role !== MemberRole.ADMIN) {
+      return Output.fail('Only admins can remove members');
+    }
+
+    const target = org.findMemberByUserId(targetId);
+    if (!target) {
+      return Output.fail('Member not found in this organization');
+    }
+
+    try {
+      org.removeMember(targetId);
+    } catch (e: unknown) {
+      return Output.fail((e as Error).message);
+    }
+
+    await this.orgRepo.save(org);
+    return Output.ok({ removed: true });
+  }
+}

--- a/formix-backend/src/modules/organizations/infra/controllers/list-members-response.dto.ts
+++ b/formix-backend/src/modules/organizations/infra/controllers/list-members-response.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MemberResponseDto {
+  @ApiProperty({ example: 'uuid-here', description: 'User ID' })
+  userId: string;
+
+  @ApiProperty({ example: 'João Silva', description: 'Member display name' })
+  name: string;
+
+  @ApiProperty({ example: 'joao@example.com', description: 'Member email' })
+  email: string;
+
+  @ApiProperty({ example: 'admin', enum: ['admin', 'member'], description: 'Member role in the organization' })
+  role: string;
+
+  @ApiProperty({ example: '2026-01-15T10:00:00.000Z', description: 'Date the member joined the organization' })
+  joinedAt: Date;
+}
+
+export class ListMembersResponseDto {
+  @ApiProperty({ type: [MemberResponseDto] })
+  members: MemberResponseDto[];
+}

--- a/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts
+++ b/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts
@@ -10,6 +10,7 @@ import mongoose from 'mongoose';
 import * as request from 'supertest';
 import { OrganizationsController } from './organizations.controller';
 import { ListMembersUseCase } from '@modules/organizations/domain/usecases/list-members.usecase';
+import { RemoveMemberUseCase } from '@modules/organizations/domain/usecases/remove-member.usecase';
 import { MongoOrganizationRepository } from '@modules/organizations/infra/repositories/mongo-organization.repository';
 import { ORGANIZATION_REPOSITORY } from '@modules/organizations/domain/repositories/organization.repository';
 import { MongoUserRepository } from '@modules/users/infra/repositories/mongo-user.repository';
@@ -60,6 +61,7 @@ describe('OrganizationsController (integration)', () => {
       controllers: [OrganizationsController],
       providers: [
         ListMembersUseCase,
+        RemoveMemberUseCase,
         { provide: ORGANIZATION_REPOSITORY, useClass: MongoOrganizationRepository },
         { provide: USER_REPOSITORY, useClass: MongoUserRepository },
         JwtStrategy,
@@ -172,6 +174,48 @@ describe('OrganizationsController (integration)', () => {
     it('should return 401 without token', async () => {
       const response = await request(app.getHttpServer())
         .get(`/organizations/${org.id.getValue()}/members`);
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('DELETE /organizations/:orgId/members/:userId', () => {
+    it('should return 200 when admin removes a member', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/organizations/${org.id.getValue()}/members/${memberUser.id.getValue()}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.removed).toBe(true);
+    });
+
+    it('should return 403 when non-admin tries to remove', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/organizations/${org.id.getValue()}/members/${adminUser.id.getValue()}`)
+        .set('Authorization', `Bearer ${memberToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should return 403 when orgId does not match token', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/organizations/${org.id.getValue()}/members/${memberUser.id.getValue()}`)
+        .set('Authorization', `Bearer ${otherOrgToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should return 400 when admin tries to remove themselves as last admin', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/organizations/${org.id.getValue()}/members/${adminUser.id.getValue()}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 401 without token', async () => {
+      const response = await request(app.getHttpServer())
+        .delete(`/organizations/${org.id.getValue()}/members/${memberUser.id.getValue()}`);
 
       expect(response.status).toBe(401);
     });

--- a/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts
+++ b/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.test.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule } from '@nestjs/config';
+import mongoose from 'mongoose';
+import * as request from 'supertest';
+import { OrganizationsController } from './organizations.controller';
+import { ListMembersUseCase } from '@modules/organizations/domain/usecases/list-members.usecase';
+import { MongoOrganizationRepository } from '@modules/organizations/infra/repositories/mongo-organization.repository';
+import { ORGANIZATION_REPOSITORY } from '@modules/organizations/domain/repositories/organization.repository';
+import { MongoUserRepository } from '@modules/users/infra/repositories/mongo-user.repository';
+import { USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
+import { OrganizationSchemaClass, OrganizationSchema } from '@modules/organizations/infra/schemas/organization.schema';
+import { UserSchemaClass, UserSchema } from '@modules/users/infra/schemas/user.schema';
+import { JwtStrategy } from '@modules/auth/infra/strategies/jwt.strategy';
+import { JwtAuthGuard } from '@modules/auth/infra/guards/jwt-auth.guard';
+import { Organization } from '@modules/organizations/domain/aggregate/organization.aggregate';
+import { OrganizationId } from '@modules/organizations/domain/aggregate/value-objects/organization-id.vo';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Slug } from '@modules/organizations/domain/aggregate/value-objects/slug.vo';
+import { MembershipEntity } from '@modules/organizations/domain/aggregate/entities/membership.entity';
+import { MembershipId } from '@modules/organizations/domain/aggregate/value-objects/membership-id.vo';
+import { MemberRole } from '@modules/organizations/domain/aggregate/value-objects/member-role.enum';
+import { User } from '@modules/users/domain/aggregate/user.aggregate';
+import { Email } from '@shared/value-objects/email.vo';
+import { Password } from '@shared/value-objects/password.vo';
+
+const TEST_SECRET = 'default-secret';
+
+describe('OrganizationsController (integration)', () => {
+  let mongod: MongoMemoryServer;
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let adminUser: User;
+  let memberUser: User;
+  let org: Organization;
+  let adminToken: string;
+  let memberToken: string;
+  let otherOrgToken: string;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        MongooseModule.forRoot(uri),
+        MongooseModule.forFeature([
+          { name: OrganizationSchemaClass.name, schema: OrganizationSchema },
+          { name: UserSchemaClass.name, schema: UserSchema },
+        ]),
+        PassportModule.register({ defaultStrategy: 'jwt' }),
+        JwtModule.register({ secret: TEST_SECRET, signOptions: { expiresIn: '15m' } }),
+      ],
+      controllers: [OrganizationsController],
+      providers: [
+        ListMembersUseCase,
+        { provide: ORGANIZATION_REPOSITORY, useClass: MongoOrganizationRepository },
+        { provide: USER_REPOSITORY, useClass: MongoUserRepository },
+        JwtStrategy,
+        JwtAuthGuard,
+        { provide: APP_GUARD, useClass: JwtAuthGuard },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    jwtService = module.get(JwtService);
+
+    const orgRepo = module.get(ORGANIZATION_REPOSITORY);
+    const userRepo = module.get(USER_REPOSITORY);
+
+    adminUser = User.create({
+      name: 'Admin User',
+      email: Email.create('admin@example.com'),
+      passwordHash: await Password.create('AdminPass1'),
+    });
+    memberUser = User.create({
+      name: 'Member User',
+      email: Email.create('member@example.com'),
+      passwordHash: await Password.create('MemberPass1'),
+    });
+    await userRepo.save(adminUser);
+    await userRepo.save(memberUser);
+
+    org = Organization.reconstitute({
+      id: OrganizationId.create(),
+      name: 'Test Org',
+      slug: Slug.create('test-org'),
+      members: [
+        MembershipEntity.reconstitute({
+          id: MembershipId.create(),
+          userId: adminUser.id,
+          role: MemberRole.ADMIN,
+          createdAt: new Date(),
+        }),
+        MembershipEntity.reconstitute({
+          id: MembershipId.create(),
+          userId: memberUser.id,
+          role: MemberRole.MEMBER,
+          createdAt: new Date(),
+        }),
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await orgRepo.save(org);
+
+    adminToken = jwtService.sign({
+      sub: adminUser.id.getValue(),
+      organizationId: org.id.getValue(),
+      role: 'admin',
+    });
+    memberToken = jwtService.sign({
+      sub: memberUser.id.getValue(),
+      organizationId: org.id.getValue(),
+      role: 'member',
+    });
+    otherOrgToken = jwtService.sign({
+      sub: adminUser.id.getValue(),
+      organizationId: 'other-org-id',
+      role: 'admin',
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  describe('GET /organizations/:orgId/members', () => {
+    it('should return 200 with members list for admin', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/organizations/${org.id.getValue()}/members`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.members).toHaveLength(2);
+      expect(response.body.members[0]).toHaveProperty('userId');
+      expect(response.body.members[0]).toHaveProperty('name');
+      expect(response.body.members[0]).toHaveProperty('email');
+      expect(response.body.members[0]).toHaveProperty('role');
+      expect(response.body.members[0]).toHaveProperty('joinedAt');
+      expect(response.body.members[0]).not.toHaveProperty('passwordHash');
+    });
+
+    it('should return 200 with members list for regular member', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/organizations/${org.id.getValue()}/members`)
+        .set('Authorization', `Bearer ${memberToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.members).toHaveLength(2);
+    });
+
+    it('should return 403 when orgId does not match token', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/organizations/${org.id.getValue()}/members`)
+        .set('Authorization', `Bearer ${otherOrgToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should return 401 without token', async () => {
+      const response = await request(app.getHttpServer())
+        .get(`/organizations/${org.id.getValue()}/members`);
+
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts
+++ b/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts
@@ -1,7 +1,10 @@
 import {
+  BadRequestException,
   Controller,
+  Delete,
   ForbiddenException,
   Get,
+  NotFoundException,
   Param,
 } from '@nestjs/common';
 import {
@@ -12,6 +15,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { ListMembersUseCase } from '@modules/organizations/domain/usecases/list-members.usecase';
+import { RemoveMemberUseCase } from '@modules/organizations/domain/usecases/remove-member.usecase';
 import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
 import { ListMembersResponseDto } from './list-members-response.dto';
 
@@ -21,6 +25,7 @@ import { ListMembersResponseDto } from './list-members-response.dto';
 export class OrganizationsController {
   constructor(
     private readonly listMembersUseCase: ListMembersUseCase,
+    private readonly removeMemberUseCase: RemoveMemberUseCase,
   ) {}
 
   @Get(':orgId/members')
@@ -39,6 +44,43 @@ export class OrganizationsController {
 
     const output = await this.listMembersUseCase.execute({ organizationId: orgId });
     if (output.isFailure) throw new ForbiddenException(output.errorMessage);
+    return output.value;
+  }
+
+  @Delete(':orgId/members/:userId')
+  @ApiOperation({ summary: 'Remove a member from an organization (admin only)' })
+  @ApiParam({ name: 'orgId', description: 'Organization ID' })
+  @ApiParam({ name: 'userId', description: 'User ID to remove' })
+  @ApiResponse({ status: 200, description: 'Member removed successfully' })
+  @ApiResponse({ status: 400, description: 'Bad request — cannot remove last admin' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not admin or wrong org' })
+  @ApiResponse({ status: 404, description: 'Member not found' })
+  async removeMember(
+    @Param('orgId') orgId: string,
+    @Param('userId') userId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<{ removed: true }> {
+    if (orgId !== user.organizationId) {
+      throw new ForbiddenException('Access denied to this organization');
+    }
+
+    const output = await this.removeMemberUseCase.execute({
+      organizationId: orgId,
+      requestingUserId: user.userId,
+      targetUserId: userId,
+    });
+
+    if (output.isFailure) {
+      if (output.errorMessage === 'Only admins can remove members') {
+        throw new ForbiddenException(output.errorMessage);
+      }
+      if (output.errorMessage === 'Member not found in this organization') {
+        throw new NotFoundException(output.errorMessage);
+      }
+      throw new BadRequestException(output.errorMessage);
+    }
+
     return output.value;
   }
 }

--- a/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts
+++ b/formix-backend/src/modules/organizations/infra/controllers/organizations.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  Param,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ListMembersUseCase } from '@modules/organizations/domain/usecases/list-members.usecase';
+import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
+import { ListMembersResponseDto } from './list-members-response.dto';
+
+@ApiTags('organizations')
+@ApiBearerAuth()
+@Controller('organizations')
+export class OrganizationsController {
+  constructor(
+    private readonly listMembersUseCase: ListMembersUseCase,
+  ) {}
+
+  @Get(':orgId/members')
+  @ApiOperation({ summary: 'List all members of an organization' })
+  @ApiParam({ name: 'orgId', description: 'Organization ID' })
+  @ApiResponse({ status: 200, description: 'List of members returned', type: ListMembersResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — orgId does not match token organization' })
+  async listMembers(
+    @Param('orgId') orgId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<ListMembersResponseDto> {
+    if (orgId !== user.organizationId) {
+      throw new ForbiddenException('Access denied to this organization');
+    }
+
+    const output = await this.listMembersUseCase.execute({ organizationId: orgId });
+    if (output.isFailure) throw new ForbiddenException(output.errorMessage);
+    return output.value;
+  }
+}

--- a/formix-backend/src/modules/organizations/organizations.module.ts
+++ b/formix-backend/src/modules/organizations/organizations.module.ts
@@ -3,12 +3,20 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { OrganizationSchemaClass, OrganizationSchema } from './infra/schemas/organization.schema';
 import { MongoOrganizationRepository } from './infra/repositories/mongo-organization.repository';
 import { ORGANIZATION_REPOSITORY } from './domain/repositories/organization.repository';
+import { ListMembersUseCase } from './domain/usecases/list-members.usecase';
+import { OrganizationsController } from './infra/controllers/organizations.controller';
+import { UsersModule } from '@modules/users/users.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: OrganizationSchemaClass.name, schema: OrganizationSchema }]),
+    UsersModule,
   ],
-  providers: [{ provide: ORGANIZATION_REPOSITORY, useClass: MongoOrganizationRepository }],
+  controllers: [OrganizationsController],
+  providers: [
+    { provide: ORGANIZATION_REPOSITORY, useClass: MongoOrganizationRepository },
+    ListMembersUseCase,
+  ],
   exports: [ORGANIZATION_REPOSITORY],
 })
 export class OrganizationsModule {}

--- a/formix-backend/src/modules/organizations/organizations.module.ts
+++ b/formix-backend/src/modules/organizations/organizations.module.ts
@@ -4,6 +4,7 @@ import { OrganizationSchemaClass, OrganizationSchema } from './infra/schemas/org
 import { MongoOrganizationRepository } from './infra/repositories/mongo-organization.repository';
 import { ORGANIZATION_REPOSITORY } from './domain/repositories/organization.repository';
 import { ListMembersUseCase } from './domain/usecases/list-members.usecase';
+import { RemoveMemberUseCase } from './domain/usecases/remove-member.usecase';
 import { OrganizationsController } from './infra/controllers/organizations.controller';
 import { UsersModule } from '@modules/users/users.module';
 
@@ -16,6 +17,7 @@ import { UsersModule } from '@modules/users/users.module';
   providers: [
     { provide: ORGANIZATION_REPOSITORY, useClass: MongoOrganizationRepository },
     ListMembersUseCase,
+    RemoveMemberUseCase,
   ],
   exports: [ORGANIZATION_REPOSITORY],
 })

--- a/formix-backend/src/modules/users/domain/usecases/get-profile.usecase.spec.ts
+++ b/formix-backend/src/modules/users/domain/usecases/get-profile.usecase.spec.ts
@@ -1,0 +1,62 @@
+import { GetProfileUseCase } from './get-profile.usecase';
+import { IUserRepository } from '@modules/users/domain/repositories/user.repository';
+import { User } from '@modules/users/domain/aggregate/user.aggregate';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Email } from '@shared/value-objects/email.vo';
+import { Password } from '@shared/value-objects/password.vo';
+import { Output } from '@shared/output';
+
+describe('GetProfileUseCase', () => {
+  let useCase: GetProfileUseCase;
+  let userRepo: jest.Mocked<IUserRepository>;
+
+  beforeEach(() => {
+    userRepo = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findByEmailConfirmationTokenHash: jest.fn(),
+      findByRefreshTokenHash: jest.fn(),
+      findByPasswordResetTokenHash: jest.fn(),
+      exists: jest.fn(),
+      save: jest.fn(),
+    };
+    useCase = new GetProfileUseCase(userRepo);
+  });
+
+  it('should return user profile without passwordHash', async () => {
+    const userId = UserId.create();
+    const user = User.reconstitute({
+      id: userId,
+      name: 'João Silva',
+      email: Email.create('joao@example.com'),
+      passwordHash: Password.fromHash('$2b$10$hashedpassword'),
+      emailConfirmed: true,
+      emailConfirmationToken: null,
+      refreshTokens: [],
+      passwordResetToken: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+
+    const result = await useCase.execute({ userId: userId.getValue() });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value).toEqual({
+      id: userId.getValue(),
+      name: 'João Silva',
+      email: 'joao@example.com',
+      emailConfirmed: true,
+    });
+    expect(result.value).not.toHaveProperty('passwordHash');
+  });
+
+  it('should return Output.fail when user not found', async () => {
+    userRepo.findById.mockResolvedValue(Output.fail('User not found'));
+
+    const result = await useCase.execute({ userId: UserId.create().getValue() });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('User not found');
+  });
+});

--- a/formix-backend/src/modules/users/domain/usecases/get-profile.usecase.ts
+++ b/formix-backend/src/modules/users/domain/usecases/get-profile.usecase.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Output } from '@shared/output';
+
+export interface GetProfileInput {
+  userId: string;
+}
+
+export interface GetProfileOutput {
+  id: string;
+  name: string;
+  email: string;
+  emailConfirmed: boolean;
+}
+
+@Injectable()
+export class GetProfileUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepo: IUserRepository,
+  ) {}
+
+  async execute(input: GetProfileInput): Promise<Output<GetProfileOutput>> {
+    const result = await this.userRepo.findById(UserId.from(input.userId));
+    if (result.isFailure) return Output.fail(result.errorMessage);
+
+    const user = result.value;
+    return Output.ok({
+      id: user.id.getValue(),
+      name: user.name,
+      email: user.email.getValue(),
+      emailConfirmed: user.emailConfirmed,
+    });
+  }
+}

--- a/formix-backend/src/modules/users/domain/usecases/update-profile.usecase.spec.ts
+++ b/formix-backend/src/modules/users/domain/usecases/update-profile.usecase.spec.ts
@@ -1,0 +1,117 @@
+import { UpdateProfileUseCase } from './update-profile.usecase';
+import { IUserRepository } from '@modules/users/domain/repositories/user.repository';
+import { User } from '@modules/users/domain/aggregate/user.aggregate';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Email } from '@shared/value-objects/email.vo';
+import { Password } from '@shared/value-objects/password.vo';
+import { Output } from '@shared/output';
+
+async function makeUser(passwordPlain = 'DefaultPass1'): Promise<User> {
+  return User.reconstitute({
+    id: UserId.create(),
+    name: 'Test User',
+    email: Email.create('test@example.com'),
+    passwordHash: await Password.create(passwordPlain),
+    emailConfirmed: false,
+    emailConfirmationToken: null,
+    refreshTokens: [],
+    passwordResetToken: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+describe('UpdateProfileUseCase', () => {
+  let useCase: UpdateProfileUseCase;
+  let userRepo: jest.Mocked<IUserRepository>;
+
+  beforeEach(() => {
+    userRepo = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findByEmailConfirmationTokenHash: jest.fn(),
+      findByRefreshTokenHash: jest.fn(),
+      findByPasswordResetTokenHash: jest.fn(),
+      exists: jest.fn(),
+      save: jest.fn(),
+    };
+    useCase = new UpdateProfileUseCase(userRepo);
+  });
+
+  it('should update name successfully', async () => {
+    const user = await makeUser();
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+    userRepo.save.mockResolvedValue();
+
+    const result = await useCase.execute({ userId: user.id.getValue(), name: 'New Name' });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value).toEqual({ updated: true });
+    expect(userRepo.save).toHaveBeenCalled();
+  });
+
+  it('should update password with correct current password', async () => {
+    const user = await makeUser('CurrentPass1');
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+    userRepo.save.mockResolvedValue();
+
+    const result = await useCase.execute({
+      userId: user.id.getValue(),
+      currentPassword: 'CurrentPass1',
+      newPassword: 'NewPass1234',
+    });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value).toEqual({ updated: true });
+    expect(userRepo.save).toHaveBeenCalled();
+  });
+
+  it('should fail when current password is incorrect', async () => {
+    const user = await makeUser('CurrentPass1');
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+
+    const result = await useCase.execute({
+      userId: user.id.getValue(),
+      currentPassword: 'WrongPass1',
+      newPassword: 'NewPass1234',
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Current password is incorrect');
+    expect(userRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('should fail when newPassword is provided without currentPassword', async () => {
+    const user = await makeUser();
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+
+    const result = await useCase.execute({
+      userId: user.id.getValue(),
+      newPassword: 'NewPass1234',
+    });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('Current password is required to change password');
+    expect(userRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('should return Output.fail when user not found', async () => {
+    userRepo.findById.mockResolvedValue(Output.fail('User not found'));
+
+    const result = await useCase.execute({ userId: UserId.create().getValue(), name: 'New Name' });
+
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toBe('User not found');
+  });
+
+  it('should not change email even when updating', async () => {
+    const user = await makeUser();
+    const originalEmail = user.email.getValue();
+    userRepo.findById.mockResolvedValue(Output.ok(user));
+    userRepo.save.mockResolvedValue();
+
+    await useCase.execute({ userId: user.id.getValue(), name: 'New Name' });
+
+    expect(user.email.getValue()).toBe(originalEmail);
+  });
+});

--- a/formix-backend/src/modules/users/domain/usecases/update-profile.usecase.ts
+++ b/formix-backend/src/modules/users/domain/usecases/update-profile.usecase.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
+import { UserId } from '@modules/users/domain/aggregate/value-objects/user-id.vo';
+import { Password } from '@shared/value-objects/password.vo';
+import { Output } from '@shared/output';
+
+export interface UpdateProfileInput {
+  userId: string;
+  name?: string;
+  currentPassword?: string;
+  newPassword?: string;
+}
+
+@Injectable()
+export class UpdateProfileUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepo: IUserRepository,
+  ) {}
+
+  async execute(input: UpdateProfileInput): Promise<Output<{ updated: true }>> {
+    const result = await this.userRepo.findById(UserId.from(input.userId));
+    if (result.isFailure) return Output.fail(result.errorMessage);
+
+    const user = result.value;
+
+    if (input.name) {
+      try {
+        user.updateName(input.name);
+      } catch (e: unknown) {
+        return Output.fail((e as Error).message);
+      }
+    }
+
+    if (input.newPassword) {
+      if (!input.currentPassword) {
+        return Output.fail('Current password is required to change password');
+      }
+
+      const isCorrect = await user.passwordHash.compare(input.currentPassword);
+      if (!isCorrect) return Output.fail('Current password is incorrect');
+
+      try {
+        const newPassword = await Password.create(input.newPassword);
+        user.updatePassword(newPassword);
+      } catch (e: unknown) {
+        return Output.fail((e as Error).message);
+      }
+    }
+
+    await this.userRepo.save(user);
+    return Output.ok({ updated: true });
+  }
+}

--- a/formix-backend/src/modules/users/infra/controllers/get-profile-response.dto.ts
+++ b/formix-backend/src/modules/users/infra/controllers/get-profile-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetProfileResponseDto {
+  @ApiProperty({ example: 'uuid-here', description: 'User ID' })
+  id: string;
+
+  @ApiProperty({ example: 'João Silva', description: 'User display name' })
+  name: string;
+
+  @ApiProperty({ example: 'joao@example.com', description: 'User email (immutable)' })
+  email: string;
+
+  @ApiProperty({ example: true, description: 'Whether the email has been confirmed' })
+  emailConfirmed: boolean;
+}

--- a/formix-backend/src/modules/users/infra/controllers/update-profile.dto.ts
+++ b/formix-backend/src/modules/users/infra/controllers/update-profile.dto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ example: 'João Silva', description: 'New display name' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'CurrentPass1', description: 'Current password (required when changing password)' })
+  @IsOptional()
+  @IsString()
+  currentPassword?: string;
+
+  @ApiPropertyOptional({ example: 'NewPass1234', description: 'New password (min 8 chars, 1 letter, 1 number)' })
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  newPassword?: string;
+}

--- a/formix-backend/src/modules/users/infra/controllers/users.controller.test.ts
+++ b/formix-backend/src/modules/users/infra/controllers/users.controller.test.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule } from '@nestjs/config';
+import mongoose from 'mongoose';
+import * as request from 'supertest';
+import { UsersController } from './users.controller';
+import { GetProfileUseCase } from '@modules/users/domain/usecases/get-profile.usecase';
+import { UpdateProfileUseCase } from '@modules/users/domain/usecases/update-profile.usecase';
+import { MongoUserRepository } from '@modules/users/infra/repositories/mongo-user.repository';
+import { USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
+import { UserSchemaClass, UserSchema } from '@modules/users/infra/schemas/user.schema';
+import { JwtStrategy } from '@modules/auth/infra/strategies/jwt.strategy';
+import { JwtAuthGuard } from '@modules/auth/infra/guards/jwt-auth.guard';
+import { User } from '@modules/users/domain/aggregate/user.aggregate';
+import { Email } from '@shared/value-objects/email.vo';
+import { Password } from '@shared/value-objects/password.vo';
+
+const TEST_SECRET = 'default-secret';
+
+describe('UsersController (integration)', () => {
+  let mongod: MongoMemoryServer;
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let user: User;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        MongooseModule.forRoot(uri),
+        MongooseModule.forFeature([{ name: UserSchemaClass.name, schema: UserSchema }]),
+        PassportModule.register({ defaultStrategy: 'jwt' }),
+        JwtModule.register({ secret: TEST_SECRET, signOptions: { expiresIn: '15m' } }),
+      ],
+      controllers: [UsersController],
+      providers: [
+        GetProfileUseCase,
+        UpdateProfileUseCase,
+        { provide: USER_REPOSITORY, useClass: MongoUserRepository },
+        JwtStrategy,
+        JwtAuthGuard,
+        { provide: APP_GUARD, useClass: JwtAuthGuard },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    jwtService = module.get(JwtService);
+
+    const userRepo = module.get(USER_REPOSITORY);
+    user = User.create({
+      name: 'Test User',
+      email: Email.create('test@example.com'),
+      passwordHash: await Password.create('TestPass1'),
+    });
+    await userRepo.save(user);
+
+    accessToken = jwtService.sign({
+      sub: user.id.getValue(),
+      organizationId: 'org-id',
+      role: 'admin',
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  describe('GET /users/me', () => {
+    it('should return 200 with user profile (no passwordHash)', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/users/me')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe(user.id.getValue());
+      expect(response.body.name).toBe('Test User');
+      expect(response.body.email).toBe('test@example.com');
+      expect(response.body.emailConfirmed).toBe(false);
+      expect(response.body.passwordHash).toBeUndefined();
+    });
+
+    it('should return 401 without token', async () => {
+      const response = await request(app.getHttpServer()).get('/users/me');
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('PATCH /users/me', () => {
+    it('should return 200 when updating name', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ name: 'Updated Name' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.updated).toBe(true);
+    });
+
+    it('should return 200 when updating password with correct current password', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ currentPassword: 'TestPass1', newPassword: 'NewPass1234' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.updated).toBe(true);
+    });
+
+    it('should return 400 when current password is incorrect', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/users/me')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ currentPassword: 'WrongPass1', newPassword: 'NewPass1234' });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 401 without token', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/users/me')
+        .send({ name: 'New Name' });
+
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/formix-backend/src/modules/users/infra/controllers/users.controller.ts
+++ b/formix-backend/src/modules/users/infra/controllers/users.controller.ts
@@ -1,0 +1,61 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Patch,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GetProfileUseCase } from '@modules/users/domain/usecases/get-profile.usecase';
+import { UpdateProfileUseCase } from '@modules/users/domain/usecases/update-profile.usecase';
+import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
+import { GetProfileResponseDto } from './get-profile-response.dto';
+import { UpdateProfileDto } from './update-profile.dto';
+
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users')
+export class UsersController {
+  constructor(
+    private readonly getProfileUseCase: GetProfileUseCase,
+    private readonly updateProfileUseCase: UpdateProfileUseCase,
+  ) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({ status: 200, description: 'User profile returned', type: GetProfileResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async getProfile(@CurrentUser() user: JwtPayload): Promise<GetProfileResponseDto> {
+    const output = await this.getProfileUseCase.execute({ userId: user.userId });
+    if (output.isFailure) throw new NotFoundException(output.errorMessage);
+    return output.value;
+  }
+
+  @Patch('me')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Update current user profile (name and/or password)' })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiResponse({ status: 200, description: 'Profile updated successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid request (e.g., incorrect current password)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateProfile(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateProfileDto,
+  ): Promise<{ updated: true }> {
+    const output = await this.updateProfileUseCase.execute({
+      userId: user.userId,
+      ...dto,
+    });
+    if (output.isFailure) throw new BadRequestException(output.errorMessage);
+    return output.value;
+  }
+}

--- a/formix-backend/src/modules/users/users.module.ts
+++ b/formix-backend/src/modules/users/users.module.ts
@@ -3,10 +3,18 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { UserSchemaClass, UserSchema } from './infra/schemas/user.schema';
 import { MongoUserRepository } from './infra/repositories/mongo-user.repository';
 import { USER_REPOSITORY } from './domain/repositories/user.repository';
+import { GetProfileUseCase } from './domain/usecases/get-profile.usecase';
+import { UpdateProfileUseCase } from './domain/usecases/update-profile.usecase';
+import { UsersController } from './infra/controllers/users.controller';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: UserSchemaClass.name, schema: UserSchema }])],
-  providers: [{ provide: USER_REPOSITORY, useClass: MongoUserRepository }],
+  controllers: [UsersController],
+  providers: [
+    { provide: USER_REPOSITORY, useClass: MongoUserRepository },
+    GetProfileUseCase,
+    UpdateProfileUseCase,
+  ],
   exports: [USER_REPOSITORY],
 })
 export class UsersModule {}

--- a/formix-frontend/src/app/(app)/settings/members/page.tsx
+++ b/formix-frontend/src/app/(app)/settings/members/page.tsx
@@ -3,21 +3,65 @@
 import { useState, useEffect } from 'react';
 import { PageContainer } from '@/components/Layout';
 import { MembersTable } from '@/modules/MembersTable/MembersTable';
-import { listMembers } from '@/services/organizations/organizations.service';
+import { RemoveMemberModal } from '@/modules/MembersTable/RemoveMemberModal';
+import { listMembers, removeMember } from '@/services/organizations/organizations.service';
 import { useAuth } from '@/hooks/useAuth';
+import { ApiError } from '@/types/api-error';
 import type { Member } from '@/services/organizations/organizations.types';
+
+interface Toast {
+  type: 'success' | 'error';
+  message: string;
+}
 
 export default function MembersPage() {
   const { user, isLoading: authLoading } = useAuth();
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
+  const [memberToRemove, setMemberToRemove] = useState<Member | null>(null);
+  const [removeLoading, setRemoveLoading] = useState(false);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  function showToast(type: 'success' | 'error', message: string) {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  async function fetchMembers() {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const data = await listMembers(user.organizationId);
+      setMembers(data);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
     if (!user) return;
-    listMembers(user.organizationId)
-      .then(setMembers)
-      .finally(() => setLoading(false));
+    fetchMembers();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
+
+  async function handleRemoveConfirm() {
+    if (!memberToRemove || !user) return;
+    setRemoveLoading(true);
+    try {
+      await removeMember(user.organizationId, memberToRemove.userId);
+      setMemberToRemove(null);
+      showToast('success', `${memberToRemove.name} foi removido da organização.`);
+      await fetchMembers();
+    } catch (err) {
+      if (err instanceof ApiError && err.statusCode === 400) {
+        showToast('error', 'Não é possível remover o único admin da organização.');
+      } else {
+        showToast('error', 'Erro ao remover membro.');
+      }
+    } finally {
+      setRemoveLoading(false);
+    }
+  }
 
   if (authLoading || loading) {
     return (
@@ -38,6 +82,22 @@ export default function MembersPage() {
         )}
       </div>
 
+      {toast && (
+        <div
+          role="alert"
+          style={{
+            padding: '12px 16px',
+            marginBottom: 24,
+            borderRadius: 6,
+            background: toast.type === 'success' ? '#d1fae5' : '#fee2e2',
+            color: toast.type === 'success' ? '#065f46' : '#991b1b',
+            border: `1px solid ${toast.type === 'success' ? '#6ee7b7' : '#fca5a5'}`,
+          }}
+        >
+          {toast.message}
+        </div>
+      )}
+
       {members.length === 0 ? (
         <p>Nenhum membro encontrado.</p>
       ) : (
@@ -45,6 +105,19 @@ export default function MembersPage() {
           members={members}
           currentUserId={user?.id ?? ''}
           isAdmin={user?.role === 'admin'}
+          onRemove={(userId) => {
+            const member = members.find((m) => m.userId === userId);
+            if (member) setMemberToRemove(member);
+          }}
+        />
+      )}
+
+      {memberToRemove && (
+        <RemoveMemberModal
+          memberName={memberToRemove.name}
+          loading={removeLoading}
+          onConfirm={handleRemoveConfirm}
+          onCancel={() => setMemberToRemove(null)}
         />
       )}
     </PageContainer>

--- a/formix-frontend/src/app/(app)/settings/members/page.tsx
+++ b/formix-frontend/src/app/(app)/settings/members/page.tsx
@@ -1,10 +1,52 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import { PageContainer } from '@/components/Layout';
+import { MembersTable } from '@/modules/MembersTable/MembersTable';
+import { listMembers } from '@/services/organizations/organizations.service';
+import { useAuth } from '@/hooks/useAuth';
+import type { Member } from '@/services/organizations/organizations.types';
 
 export default function MembersPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    listMembers(user.organizationId)
+      .then(setMembers)
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  if (authLoading || loading) {
+    return (
+      <PageContainer>
+        <p>Carregando membros...</p>
+      </PageContainer>
+    );
+  }
+
   return (
     <PageContainer>
-      <h1>Membros</h1>
-      <p>Conteúdo em breve (US-020).</p>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <h1 style={{ margin: 0 }}>Membros</h1>
+        {user?.role === 'admin' && (
+          <button disabled style={{ opacity: 0.5 }}>
+            Convidar membro
+          </button>
+        )}
+      </div>
+
+      {members.length === 0 ? (
+        <p>Nenhum membro encontrado.</p>
+      ) : (
+        <MembersTable
+          members={members}
+          currentUserId={user?.id ?? ''}
+          isAdmin={user?.role === 'admin'}
+        />
+      )}
     </PageContainer>
   );
 }

--- a/formix-frontend/src/app/(app)/settings/profile/page.tsx
+++ b/formix-frontend/src/app/(app)/settings/profile/page.tsx
@@ -1,10 +1,166 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import { PageContainer } from '@/components/Layout';
+import { TextInput } from '@/components/inputs/TextInput';
+import { getProfile, updateProfile } from '@/services/users/users.service';
+import { ApiError } from '@/types/api-error';
+import type { UserProfile } from '@/services/users/users.types';
+
+interface Toast {
+  type: 'success' | 'error';
+  message: string;
+}
 
 export default function ProfilePage() {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [name, setName] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [nameLoading, setNameLoading] = useState(false);
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [toast, setToast] = useState<Toast | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProfile().then((data) => {
+      setProfile(data);
+      setName(data.name);
+    });
+  }, []);
+
+  function showToast(type: 'success' | 'error', message: string) {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  async function handleSaveName(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setNameLoading(true);
+    try {
+      await updateProfile({ name: name.trim() });
+      setProfile((prev) => prev ? { ...prev, name: name.trim() } : prev);
+      showToast('success', 'Nome atualizado com sucesso.');
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Erro ao atualizar nome.';
+      showToast('error', message);
+    } finally {
+      setNameLoading(false);
+    }
+  }
+
+  async function handleChangePassword(e: React.FormEvent) {
+    e.preventDefault();
+    setPasswordError(null);
+    if (newPassword !== confirmPassword) {
+      setPasswordError('A nova senha e a confirmação não coincidem.');
+      return;
+    }
+    setPasswordLoading(true);
+    try {
+      await updateProfile({ currentPassword, newPassword });
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      showToast('success', 'Senha alterada com sucesso.');
+    } catch (err) {
+      if (err instanceof ApiError && err.statusCode === 400) {
+        showToast('error', 'Senha atual incorreta.');
+      } else {
+        showToast('error', 'Erro ao alterar senha.');
+      }
+    } finally {
+      setPasswordLoading(false);
+    }
+  }
+
   return (
     <PageContainer>
       <h1>Perfil</h1>
-      <p>Conteúdo em breve (US-018).</p>
+
+      {toast && (
+        <div
+          role="alert"
+          style={{
+            padding: '12px 16px',
+            marginBottom: 24,
+            borderRadius: 6,
+            background: toast.type === 'success' ? '#d1fae5' : '#fee2e2',
+            color: toast.type === 'success' ? '#065f46' : '#991b1b',
+            border: `1px solid ${toast.type === 'success' ? '#6ee7b7' : '#fca5a5'}`,
+          }}
+        >
+          {toast.message}
+        </div>
+      )}
+
+      <section style={{ marginBottom: 40, maxWidth: 480 }}>
+        <h2>Dados pessoais</h2>
+        <form onSubmit={handleSaveName} noValidate>
+          <div style={{ marginBottom: 16 }}>
+            <TextInput
+              label="Nome"
+              value={name}
+              onChange={setName}
+              required
+              disabled={nameLoading || !profile}
+            />
+          </div>
+          <div style={{ marginBottom: 16 }}>
+            <TextInput
+              label="Email"
+              value={profile?.email ?? ''}
+              onChange={() => {}}
+              disabled
+            />
+          </div>
+          <button type="submit" disabled={nameLoading || !profile}>
+            {nameLoading ? 'Salvando...' : 'Salvar'}
+          </button>
+        </form>
+      </section>
+
+      <section style={{ maxWidth: 480 }}>
+        <h2>Alterar senha</h2>
+        <form onSubmit={handleChangePassword} noValidate>
+          <div style={{ marginBottom: 16 }}>
+            <TextInput
+              label="Senha atual"
+              value={currentPassword}
+              onChange={setCurrentPassword}
+              type="password"
+              required
+              disabled={passwordLoading}
+            />
+          </div>
+          <div style={{ marginBottom: 16 }}>
+            <TextInput
+              label="Nova senha"
+              value={newPassword}
+              onChange={setNewPassword}
+              type="password"
+              required
+              disabled={passwordLoading}
+            />
+          </div>
+          <div style={{ marginBottom: 16 }}>
+            <TextInput
+              label="Confirmar nova senha"
+              value={confirmPassword}
+              onChange={setConfirmPassword}
+              type="password"
+              required
+              disabled={passwordLoading}
+              error={passwordError ?? undefined}
+            />
+          </div>
+          <button type="submit" disabled={passwordLoading}>
+            {passwordLoading ? 'Alterando...' : 'Alterar senha'}
+          </button>
+        </form>
+      </section>
     </PageContainer>
   );
 }

--- a/formix-frontend/src/modules/MembersTable/MembersTable.module.css
+++ b/formix-frontend/src/modules/MembersTable/MembersTable.module.css
@@ -1,0 +1,49 @@
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.table th {
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 600;
+  color: #374151;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid #f3f4f6;
+  color: #111827;
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.table tr:hover td {
+  background: #f9fafb;
+}
+
+.removeBtn {
+  padding: 4px 12px;
+  border-radius: 6px;
+  border: 1px solid #fca5a5;
+  background: #fff;
+  color: #dc2626;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.removeBtn:hover {
+  background: #fee2e2;
+}

--- a/formix-frontend/src/modules/MembersTable/MembersTable.tsx
+++ b/formix-frontend/src/modules/MembersTable/MembersTable.tsx
@@ -1,0 +1,53 @@
+import type { Member } from '@/services/organizations/organizations.types';
+import { RoleBadge } from './RoleBadge';
+import styles from './MembersTable.module.css';
+
+interface MembersTableProps {
+  members: Member[];
+  currentUserId: string;
+  isAdmin: boolean;
+  onRemove?: (userId: string) => void;
+}
+
+export function MembersTable({ members, currentUserId, isAdmin, onRemove }: MembersTableProps) {
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table} aria-label="Lista de membros">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Email</th>
+            <th>Função</th>
+            <th>Entrou em</th>
+            {isAdmin && <th>Ações</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((member) => (
+            <tr key={member.userId}>
+              <td>{member.name}</td>
+              <td>{member.email}</td>
+              <td>
+                <RoleBadge role={member.role} />
+              </td>
+              <td>{new Date(member.joinedAt).toLocaleDateString('pt-BR')}</td>
+              {isAdmin && (
+                <td>
+                  {member.userId !== currentUserId && (
+                    <button
+                      className={styles.removeBtn}
+                      onClick={() => onRemove?.(member.userId)}
+                      aria-label={`Remover ${member.name}`}
+                    >
+                      Remover
+                    </button>
+                  )}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/formix-frontend/src/modules/MembersTable/RemoveMemberModal.module.css
+++ b/formix-frontend/src/modules/MembersTable/RemoveMemberModal.module.css
@@ -1,0 +1,79 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.dialog {
+  background: #fff;
+  border-radius: 10px;
+  padding: 32px;
+  width: 100%;
+  max-width: 440px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+
+.title {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.description {
+  margin: 0 0 28px;
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.memberName {
+  font-weight: 600;
+  color: #111827;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.cancelBtn {
+  padding: 8px 20px;
+  border-radius: 6px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.cancelBtn:hover {
+  background: #f9fafb;
+}
+
+.removeBtn {
+  padding: 8px 20px;
+  border-radius: 6px;
+  border: none;
+  background: #dc2626;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.removeBtn:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.removeBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/formix-frontend/src/modules/MembersTable/RemoveMemberModal.tsx
+++ b/formix-frontend/src/modules/MembersTable/RemoveMemberModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import styles from './RemoveMemberModal.module.css';
+
+interface RemoveMemberModalProps {
+  memberName: string;
+  loading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function RemoveMemberModal({ memberName, loading, onConfirm, onCancel }: RemoveMemberModalProps) {
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelBtnRef.current?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onCancel]);
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="remove-modal-title"
+    >
+      <div className={styles.dialog}>
+        <h2 id="remove-modal-title" className={styles.title}>Remover membro</h2>
+        <p className={styles.description}>
+          Tem certeza que deseja remover{' '}
+          <span className={styles.memberName}>{memberName}</span> da organização?
+          Esta ação não pode ser desfeita.
+        </p>
+        <div className={styles.actions}>
+          <button
+            ref={cancelBtnRef}
+            className={styles.cancelBtn}
+            onClick={onCancel}
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            className={styles.removeBtn}
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading ? 'Removendo...' : 'Remover'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/formix-frontend/src/modules/MembersTable/RoleBadge.tsx
+++ b/formix-frontend/src/modules/MembersTable/RoleBadge.tsx
@@ -1,0 +1,23 @@
+interface RoleBadgeProps {
+  role: 'admin' | 'member';
+}
+
+export function RoleBadge({ role }: RoleBadgeProps) {
+  const isAdmin = role === 'admin';
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 10px',
+        borderRadius: 12,
+        fontSize: 12,
+        fontWeight: 600,
+        background: isAdmin ? '#dbeafe' : '#f3f4f6',
+        color: isAdmin ? '#1d4ed8' : '#6b7280',
+        border: `1px solid ${isAdmin ? '#bfdbfe' : '#e5e7eb'}`,
+      }}
+    >
+      {isAdmin ? 'Admin' : 'Membro'}
+    </span>
+  );
+}

--- a/formix-frontend/src/services/organizations/organizations.service.ts
+++ b/formix-frontend/src/services/organizations/organizations.service.ts
@@ -5,3 +5,7 @@ export async function listMembers(orgId: string): Promise<Member[]> {
   const response = await httpClient.get<{ members: Member[] }>(`/organizations/${orgId}/members`);
   return response.data.members;
 }
+
+export async function removeMember(orgId: string, userId: string): Promise<void> {
+  await httpClient.delete(`/organizations/${orgId}/members/${userId}`);
+}

--- a/formix-frontend/src/services/organizations/organizations.service.ts
+++ b/formix-frontend/src/services/organizations/organizations.service.ts
@@ -1,0 +1,7 @@
+import { httpClient } from '@/services/http-client';
+import type { Member } from './organizations.types';
+
+export async function listMembers(orgId: string): Promise<Member[]> {
+  const response = await httpClient.get<{ members: Member[] }>(`/organizations/${orgId}/members`);
+  return response.data.members;
+}

--- a/formix-frontend/src/services/organizations/organizations.types.ts
+++ b/formix-frontend/src/services/organizations/organizations.types.ts
@@ -1,0 +1,7 @@
+export interface Member {
+  userId: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+  joinedAt: string;
+}

--- a/formix-frontend/src/services/users/users.service.ts
+++ b/formix-frontend/src/services/users/users.service.ts
@@ -1,0 +1,11 @@
+import { httpClient } from '@/services/http-client';
+import type { UserProfile, UpdateProfileInput } from './users.types';
+
+export async function getProfile(): Promise<UserProfile> {
+  const response = await httpClient.get<UserProfile>('/users/me');
+  return response.data;
+}
+
+export async function updateProfile(data: UpdateProfileInput): Promise<void> {
+  await httpClient.patch('/users/me', data);
+}

--- a/formix-frontend/src/services/users/users.types.ts
+++ b/formix-frontend/src/services/users/users.types.ts
@@ -1,0 +1,12 @@
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  emailConfirmed: boolean;
+}
+
+export interface UpdateProfileInput {
+  name?: string;
+  currentPassword?: string;
+  newPassword?: string;
+}


### PR DESCRIPTION
## Descrição

Implementa a Fase 4 completa de gestão de usuários: perfil do usuário (GET/PATCH /users/me), listagem de membros da organização (GET /organizations/:orgId/members) e remoção de membros (DELETE /organizations/:orgId/members/:userId). Também entrega as páginas de frontend correspondentes: perfil editável e tabela de membros com modal de confirmação de remoção.

---

## Closes

Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30

---

## Commits

### `3d238c5` — feat(users): implement get-profile and update-profile use cases

Adiciona dois usecases à camada domain do módulo `users`:
- `get-profile.usecase.ts`: recebe `userId`, busca o usuário via `IUserRepository.findById` e retorna `{ id, name, email, emailConfirmed }` sem expor o `passwordHash`. Retorna `Output.fail` se o usuário não for encontrado.
- `update-profile.usecase.ts`: aceita `name`, `currentPassword` e `newPassword`. Valida a senha atual via `user.passwordHash.compare()` antes de aplicar a nova hash. Email é imutável e nunca alterado.
- Ambos os usecases seguem o padrão `Output<T>` — nenhum `throw` interno.
- Specs TDD cobrem: perfil sem passwordHash, usuário não encontrado, atualizar nome, trocar senha com senha correta, rejeitar senha atual incorreta, exigir currentPassword ao mudar senha.

---

### `2e69395` — feat(users): add GET /users/me and PATCH /users/me endpoints

Cria a infra layer do módulo `users`:
- `users.controller.ts`: expõe `GET /users/me` (retorna perfil via `@CurrentUser()`) e `PATCH /users/me` (atualiza nome/senha). Documentação Swagger completa com `@ApiTags`, `@ApiBearerAuth`, `@ApiOperation`, `@ApiBody`, `@ApiResponse`.
- `get-profile-response.dto.ts`: DTO de resposta com `@ApiProperty` para `id`, `name`, `email`, `emailConfirmed`.
- `update-profile.dto.ts`: DTO com campos opcionais `name`, `currentPassword`, `newPassword` com validações `class-validator`.
- `users.controller.test.ts`: testes de integração com `MongoMemoryServer` + `JwtModule` usando `default-secret` (compatível com `JwtStrategy` default). Testa 200 para GET/PATCH autenticados, 400 para senha errada, 401 sem token.
- `users.module.ts`: registra `UsersController`, `GetProfileUseCase` e `UpdateProfileUseCase` como providers.

---

### `26d52c0` — feat(frontend): add profile page with get and update profile

Entrega a página `/settings/profile`:
- `users.types.ts`: interfaces `UserProfile` e `UpdateProfileInput`.
- `users.service.ts`: funções `getProfile()` e `updateProfile()` usando `httpClient`.
- `profile/page.tsx`: página client-side com dois formulários — "Dados pessoais" (nome editável, email read-only) e "Alterar senha" (senha atual, nova senha, confirmar). Inclui validação client-side `newPassword === confirmPassword`, loading state por botão, e banner de feedback inline (sucesso/erro) com auto-dismiss de 4s.

---

### `107dad4` — feat(organizations): implement list-members use case

Adiciona `list-members.usecase.ts` à camada domain do módulo `organizations`:
- Input: `{ organizationId }`. Busca a organização via `IOrganizationRepository.findById`, itera sobre os memberships e enriquece com dados de usuário via `IUserRepository.findById`.
- Retorna `Output.ok({ members: MemberDto[] })` com `userId`, `name`, `email`, `role`, `joinedAt`. Membros cujo usuário não for encontrado são silenciosamente ignorados.
- Spec cobre: lista com dados de usuário, organização não encontrada, isolamento de membros por org.

---

### `05ce9bd` — feat(organizations): add GET /organizations/:orgId/members endpoint

Cria a infra layer do módulo `organizations`:
- `organizations.controller.ts`: expõe `GET /organizations/:orgId/members`. Valida que `orgId === token.organizationId` para garantir isolamento multi-tenant (retorna 403 se divergir). Qualquer membro (admin ou member) pode listar.
- `list-members-response.dto.ts`: DTOs `MemberResponseDto` e `ListMembersResponseDto` com `@ApiProperty`.
- `organizations.controller.test.ts`: testes de integração com MongoDB em memória. Cobre: 200 para admin, 200 para member, 403 para org errada, 401 sem token.
- `organizations.module.ts`: importa `UsersModule` (para injetar `IUserRepository`), registra `ListMembersUseCase` e `OrganizationsController`.

---

### `6a18d0e` — feat(organizations): implement remove-member use case

Adiciona `remove-member.usecase.ts`:
- Input: `{ organizationId, requestingUserId, targetUserId }`. Verifica que o requester é admin, que o target existe na org e delega a remoção ao aggregate via `org.removeMember(targetId)` (que lança `DomainError` se for o último admin).
- Retorna `Output.fail` para: não-admin tentando remover, membro não encontrado, organização não encontrada. Captura `DomainError` do aggregate (último admin) e converte em `Output.fail`.
- Spec TDD cobre todos esses cenários: 5 testes.

---

### `1cffc41` — feat(organizations): add DELETE /organizations/:orgId/members/:userId endpoint

Estende o `organizations.controller.ts` com o endpoint `DELETE /organizations/:orgId/members/:userId`:
- Valida `orgId === token.organizationId` (403 se divergir).
- Mapeia erros do usecase para HTTP: `Only admins can remove members` → 403, `Member not found` → 404, `Cannot remove the last admin` → 400.
- Swagger documentado com todos os status possíveis.
- Testes de integração adicionados: 200 para admin removendo member, 403 para non-admin, 403 para org errada, 400 para último admin, 401 sem token.
- `organizations.module.ts`: adiciona `RemoveMemberUseCase` como provider.

---

### `5ebffd9` — feat(frontend): add remove member modal and integrate with members page

Adiciona o modal de confirmação e integra na página de membros:
- `RemoveMemberModal.tsx`: modal acessível com `role="dialog"`, foco inicial no botão "Cancelar", fecha com Escape e clique no overlay, loading state no botão "Remover".
- `RemoveMemberModal.module.css`: estilos do overlay e dialog.
- `organizations.service.ts`: adiciona `removeMember(orgId, userId)`.
- `members/page.tsx`: estado `memberToRemove` controla abertura do modal. Após remoção: modal fecha, lista é recarregada, toast de sucesso exibido. Erros da API (400 = último admin) são exibidos como toast de erro.

---

## Checklist

- [x] Todos os testes passando (157 testes, 30 suites)
- [x] `npm run typecheck` passa no backend e frontend
- [x] `npm run build` passa no frontend
- [x] Sem arquivos sensíveis (.env, secrets)
- [x] Import rules do DDD respeitadas (domain não importa infra)
- [x] Swagger documentado em todos os endpoints novos
- [x] `progress.md` atualizado com todas as USs da fase
- [x] Multi-tenancy: queries filtram por organizationId