### PR TITLE
feat(responses): implement phase 7 — responses collection and viewing

### DIFF
--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -609,3 +609,30 @@
   - `formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts`
   - `formix-backend/src/modules/responses/responses.module.ts`
 - **Verificação:** typecheck OK, testes OK (10 unit + 8 integration)
+
+### features/start US-039: Submeter Resposta — Backend
+- **Status:** Concluído
+- **Data:** 2026-03-19
+- **Arquivos criados:**
+  - `formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.ts`
+  - `formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.spec.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/submit-response.dto.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/forms/domain/usecases/delete-form.usecase.ts` (cascata)
+  - `formix-backend/src/modules/responses/responses.module.ts`
+  - `formix-backend/src/app.module.ts`
+- **Verificação:** typecheck OK, testes OK (9 unit + 8 integration)
+
+### features/start US-041: Visualizar Respostas de um Formulário — Backend
+- **Status:** Concluído
+- **Data:** 2026-03-19
+- **Arquivos criados:**
+  - `formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.ts`
+  - `formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.spec.ts`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts`
+  - `formix-backend/src/modules/responses/responses.module.ts`
+- **Verificação:** typecheck OK, testes OK (4 unit + GET integration tests)

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -636,3 +636,36 @@
   - `formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts`
   - `formix-backend/src/modules/responses/responses.module.ts`
 - **Verificação:** typecheck OK, testes OK (4 unit + GET integration tests)
+
+### features/start US-040: Página Pública de Resposta — Frontend
+- **Status:** Concluído
+- **Data:** 2026-03-19
+- **Arquivos criados:**
+  - `formix-backend/src/modules/forms/domain/usecases/get-public-form.usecase.ts`
+  - `formix-frontend/src/services/responses/responses.types.ts`
+  - `formix-frontend/src/services/responses/responses.service.ts`
+  - `formix-frontend/src/modules/QuestionRenderer/QuestionRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/TextRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/TextareaRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/CheckboxRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/RadioRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/ToggleRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/DropdownRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/NumberRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/DateRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/RatingRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/FileRenderer.tsx`
+  - `formix-frontend/src/modules/QuestionRenderer/renderers/EmailRenderer.tsx`
+  - `formix-frontend/src/app/(public)/f/[publicToken]/page.tsx`
+- **Arquivos modificados:**
+  - `formix-backend/src/modules/forms/forms.module.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.ts`
+  - `formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts`
+- **Verificação:** typecheck OK, build OK (frontend), testes OK (backend)
+
+### features/start US-042: Visualizar Respostas — Frontend
+- **Status:** Concluído
+- **Data:** 2026-03-19
+- **Arquivos modificados:**
+  - `formix-frontend/src/app/(app)/forms/[id]/responses/page.tsx`
+- **Verificação:** typecheck OK, build OK

--- a/docs/features/progress.md
+++ b/docs/features/progress.md
@@ -588,3 +588,24 @@
   - `formix-frontend/src/app/(app)/forms/new/page.tsx`
   - `formix-frontend/src/app/(app)/forms/[id]/edit/page.tsx`
 - **Verificação:** typecheck OK, build OK
+
+### features/start US-038: Schemas MongoDB — Responses e Response_Emails
+- **Status:** Concluído
+- **Data:** 2026-03-19
+- **Arquivos criados:**
+  - `formix-backend/src/modules/responses/domain/aggregate/value-objects/response-id.vo.ts`
+  - `formix-backend/src/modules/responses/domain/aggregate/value-objects/response-email-id.vo.ts`
+  - `formix-backend/src/modules/responses/domain/aggregate/response.aggregate.ts`
+  - `formix-backend/src/modules/responses/domain/aggregate/response.aggregate.spec.ts`
+  - `formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.ts`
+  - `formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.spec.ts`
+  - `formix-backend/src/modules/responses/domain/repositories/response.repository.ts`
+  - `formix-backend/src/modules/responses/domain/repositories/response-email.repository.ts`
+  - `formix-backend/src/modules/responses/infra/schemas/response.schema.ts`
+  - `formix-backend/src/modules/responses/infra/schemas/response-email.schema.ts`
+  - `formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.ts`
+  - `formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.test.ts`
+  - `formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.ts`
+  - `formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts`
+  - `formix-backend/src/modules/responses/responses.module.ts`
+- **Verificação:** typecheck OK, testes OK (10 unit + 8 integration)

--- a/formix-backend/src/app.module.ts
+++ b/formix-backend/src/app.module.ts
@@ -8,10 +8,11 @@ import { OrganizationsModule } from '@modules/organizations/organizations.module
 import { AuthModule } from '@modules/auth/auth.module';
 import { InvitationsModule } from '@modules/invitations/invitations.module';
 import { FormsModule } from '@modules/forms/forms.module';
+import { ResponsesModule } from '@modules/responses/responses.module';
 import { JwtAuthGuard } from '@modules/auth/infra/guards/jwt-auth.guard';
 
 @Module({
-  imports: [EnvironmentModule, DatabaseModule, EmailModule, UsersModule, OrganizationsModule, AuthModule, InvitationsModule, FormsModule],
+  imports: [EnvironmentModule, DatabaseModule, EmailModule, UsersModule, OrganizationsModule, AuthModule, InvitationsModule, FormsModule, ResponsesModule],
   providers: [
     {
       provide: APP_GUARD,

--- a/formix-backend/src/modules/forms/domain/usecases/delete-form.usecase.ts
+++ b/formix-backend/src/modules/forms/domain/usecases/delete-form.usecase.ts
@@ -1,6 +1,8 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import { IFormRepository, FORM_REPOSITORY } from '../repositories/form.repository';
 import { IQuestionRepository, QUESTION_REPOSITORY } from '../repositories/question.repository';
+import { IResponseRepository, RESPONSE_REPOSITORY } from '@modules/responses/domain/repositories/response.repository';
+import { IResponseEmailRepository, RESPONSE_EMAIL_REPOSITORY } from '@modules/responses/domain/repositories/response-email.repository';
 import { FormId } from '../aggregate/value-objects/form-id.vo';
 import { Output } from '@shared/output';
 
@@ -18,6 +20,8 @@ export class DeleteFormUseCase {
   constructor(
     @Inject(FORM_REPOSITORY) private readonly formRepository: IFormRepository,
     @Inject(QUESTION_REPOSITORY) private readonly questionRepository: IQuestionRepository,
+    @Optional() @Inject(RESPONSE_REPOSITORY) private readonly responseRepository?: IResponseRepository,
+    @Optional() @Inject(RESPONSE_EMAIL_REPOSITORY) private readonly responseEmailRepository?: IResponseEmailRepository,
   ) {}
 
   async execute(input: DeleteFormInput): Promise<Output<DeleteFormOutput>> {
@@ -39,6 +43,8 @@ export class DeleteFormUseCase {
     }
 
     await this.questionRepository.deleteByFormId(input.formId);
+    if (this.responseRepository) await this.responseRepository.deleteByFormId(input.formId);
+    if (this.responseEmailRepository) await this.responseEmailRepository.deleteByFormId(input.formId);
     await this.formRepository.delete(formId);
 
     return Output.ok({ deleted: true });

--- a/formix-backend/src/modules/forms/domain/usecases/get-public-form.usecase.ts
+++ b/formix-backend/src/modules/forms/domain/usecases/get-public-form.usecase.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IFormRepository, FORM_REPOSITORY } from '../repositories/form.repository';
+import { IQuestionRepository, QUESTION_REPOSITORY } from '../repositories/question.repository';
+import { Output } from '@shared/output';
+
+export interface GetPublicFormOutput {
+  id: string;
+  title: string;
+  description?: string;
+  status: string;
+  questions: {
+    id: string;
+    type: string;
+    label: string;
+    description?: string;
+    required: boolean;
+    order: number;
+    options?: string[];
+    validation?: { min?: number; max?: number; pattern?: string };
+  }[];
+}
+
+@Injectable()
+export class GetPublicFormUseCase {
+  constructor(
+    @Inject(FORM_REPOSITORY) private readonly formRepository: IFormRepository,
+    @Inject(QUESTION_REPOSITORY) private readonly questionRepository: IQuestionRepository,
+  ) {}
+
+  async execute(publicToken: string): Promise<Output<GetPublicFormOutput>> {
+    const formResult = await this.formRepository.findByPublicToken(publicToken);
+    if (formResult.isFailure) return Output.fail('Form not found');
+
+    const form = formResult.value;
+    const questions = await this.questionRepository.findByFormIdOrdered(form.id.getValue());
+
+    return Output.ok({
+      id: form.id.getValue(),
+      title: form.title,
+      description: form.description,
+      status: form.status.getValue(),
+      questions: questions.map(q => ({
+        id: q.id.getValue(),
+        type: q.type.getValue(),
+        label: q.label,
+        description: q.description,
+        required: q.required,
+        order: q.order,
+        options: q.options,
+        validation: q.validation,
+      })),
+    });
+  }
+}

--- a/formix-backend/src/modules/forms/forms.module.ts
+++ b/formix-backend/src/modules/forms/forms.module.ts
@@ -17,6 +17,7 @@ import { RemoveQuestionUseCase } from './domain/usecases/remove-question.usecase
 import { ReorderQuestionsUseCase } from './domain/usecases/reorder-questions.usecase';
 import { PublishFormUseCase } from './domain/usecases/publish-form.usecase';
 import { CloseFormUseCase } from './domain/usecases/close-form.usecase';
+import { GetPublicFormUseCase } from './domain/usecases/get-public-form.usecase';
 import { FormsController } from './infra/controllers/forms.controller';
 
 @Module({
@@ -41,7 +42,8 @@ import { FormsController } from './infra/controllers/forms.controller';
     ReorderQuestionsUseCase,
     PublishFormUseCase,
     CloseFormUseCase,
+    GetPublicFormUseCase,
   ],
-  exports: [FORM_REPOSITORY, QUESTION_REPOSITORY],
+  exports: [FORM_REPOSITORY, QUESTION_REPOSITORY, GetPublicFormUseCase],
 })
 export class FormsModule {}

--- a/formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.spec.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.spec.ts
@@ -1,0 +1,46 @@
+import { ResponseEmailAggregate } from './response-email.aggregate';
+import { ResponseEmailId } from './value-objects/response-email-id.vo';
+
+describe('ResponseEmailAggregate', () => {
+  describe('create', () => {
+    it('should create with formId and emailHash', () => {
+      const re = ResponseEmailAggregate.create('form-123', 'abc123hash');
+      expect(re.formId).toBe('form-123');
+      expect(re.emailHash).toBe('abc123hash');
+      expect(re.id).toBeDefined();
+      expect(re.respondedAt).toBeInstanceOf(Date);
+    });
+
+    it('should throw if formId is missing', () => {
+      expect(() => ResponseEmailAggregate.create('', 'hash')).toThrow('formId is required');
+    });
+
+    it('should throw if emailHash is missing', () => {
+      expect(() => ResponseEmailAggregate.create('form-123', '')).toThrow('emailHash is required');
+    });
+
+    it('should NOT have responseId or any response reference', () => {
+      const re = ResponseEmailAggregate.create('form-123', 'hash');
+      const props = re as unknown as Record<string, unknown>;
+      expect(props['responseId']).toBeUndefined();
+      expect(props['email']).toBeUndefined();
+    });
+  });
+
+  describe('reconstitute', () => {
+    it('should reconstitute from persisted data', () => {
+      const id = ResponseEmailId.create();
+      const respondedAt = new Date('2026-01-01');
+      const re = ResponseEmailAggregate.reconstitute({
+        id,
+        formId: 'form-abc',
+        emailHash: 'hashvalue',
+        respondedAt,
+      });
+      expect(re.id.getValue()).toBe(id.getValue());
+      expect(re.formId).toBe('form-abc');
+      expect(re.emailHash).toBe('hashvalue');
+      expect(re.respondedAt).toBe(respondedAt);
+    });
+  });
+});

--- a/formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/response-email.aggregate.ts
@@ -1,0 +1,48 @@
+import { ResponseEmailId } from './value-objects/response-email-id.vo';
+
+interface ResponseEmailProps {
+  id: ResponseEmailId;
+  formId: string;
+  emailHash: string;
+  respondedAt: Date;
+}
+
+export class ResponseEmailAggregate {
+  private props: ResponseEmailProps;
+
+  private constructor(props: ResponseEmailProps) {
+    this.props = props;
+  }
+
+  static create(formId: string, emailHash: string): ResponseEmailAggregate {
+    if (!formId?.trim()) throw new Error('formId is required');
+    if (!emailHash?.trim()) throw new Error('emailHash is required');
+
+    return new ResponseEmailAggregate({
+      id: ResponseEmailId.create(),
+      formId,
+      emailHash,
+      respondedAt: new Date(),
+    });
+  }
+
+  static reconstitute(props: ResponseEmailProps): ResponseEmailAggregate {
+    return new ResponseEmailAggregate(props);
+  }
+
+  get id(): ResponseEmailId {
+    return this.props.id;
+  }
+
+  get formId(): string {
+    return this.props.formId;
+  }
+
+  get emailHash(): string {
+    return this.props.emailHash;
+  }
+
+  get respondedAt(): Date {
+    return this.props.respondedAt;
+  }
+}

--- a/formix-backend/src/modules/responses/domain/aggregate/response.aggregate.spec.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/response.aggregate.spec.ts
@@ -1,0 +1,71 @@
+import { ResponseAggregate } from './response.aggregate';
+import { ResponseId } from './value-objects/response-id.vo';
+
+describe('ResponseAggregate', () => {
+  const validInput = {
+    formId: 'form-123',
+    organizationId: 'org-123',
+    answers: [
+      { questionId: 'q-1', value: 'Hello' },
+      { questionId: 'q-2', value: 42 },
+    ],
+  };
+
+  describe('create', () => {
+    it('should create a response with answers', () => {
+      const response = ResponseAggregate.create(validInput);
+      expect(response.formId).toBe('form-123');
+      expect(response.organizationId).toBe('org-123');
+      expect(response.answers).toHaveLength(2);
+      expect(response.answers[0].questionId).toBe('q-1');
+      expect(response.answers[0].value).toBe('Hello');
+      expect(response.id).toBeDefined();
+      expect(response.submittedAt).toBeInstanceOf(Date);
+    });
+
+    it('should throw if formId is missing', () => {
+      expect(() =>
+        ResponseAggregate.create({ ...validInput, formId: '' }),
+      ).toThrow('formId is required');
+    });
+
+    it('should throw if organizationId is missing', () => {
+      expect(() =>
+        ResponseAggregate.create({ ...validInput, organizationId: '' }),
+      ).toThrow('organizationId is required');
+    });
+
+    it('should NOT have email, emailHash, userId or IP fields', () => {
+      const response = ResponseAggregate.create(validInput);
+      const keys = Object.keys(response);
+      expect(keys).not.toContain('email');
+      expect(keys).not.toContain('emailHash');
+      expect(keys).not.toContain('userId');
+      expect(keys).not.toContain('ip');
+
+      // Also check the plain object returned
+      const props = response as unknown as Record<string, unknown>;
+      expect(props['email']).toBeUndefined();
+      expect(props['emailHash']).toBeUndefined();
+      expect(props['userId']).toBeUndefined();
+      expect(props['ip']).toBeUndefined();
+    });
+  });
+
+  describe('reconstitute', () => {
+    it('should reconstitute a response from persisted data', () => {
+      const id = ResponseId.create();
+      const submittedAt = new Date('2026-01-01');
+      const response = ResponseAggregate.reconstitute({
+        id,
+        formId: 'form-abc',
+        organizationId: 'org-abc',
+        answers: [{ questionId: 'q-1', value: 'text' }],
+        submittedAt,
+      });
+      expect(response.id.getValue()).toBe(id.getValue());
+      expect(response.formId).toBe('form-abc');
+      expect(response.submittedAt).toBe(submittedAt);
+    });
+  });
+});

--- a/formix-backend/src/modules/responses/domain/aggregate/response.aggregate.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/response.aggregate.ts
@@ -1,0 +1,65 @@
+import { ResponseId } from './value-objects/response-id.vo';
+
+export interface Answer {
+  questionId: string;
+  value: unknown;
+}
+
+interface ResponseProps {
+  id: ResponseId;
+  formId: string;
+  organizationId: string;
+  answers: Answer[];
+  submittedAt: Date;
+}
+
+export interface CreateResponseInput {
+  formId: string;
+  organizationId: string;
+  answers: Answer[];
+}
+
+export class ResponseAggregate {
+  private props: ResponseProps;
+
+  private constructor(props: ResponseProps) {
+    this.props = props;
+  }
+
+  static create(input: CreateResponseInput): ResponseAggregate {
+    if (!input.formId?.trim()) throw new Error('formId is required');
+    if (!input.organizationId?.trim()) throw new Error('organizationId is required');
+
+    return new ResponseAggregate({
+      id: ResponseId.create(),
+      formId: input.formId,
+      organizationId: input.organizationId,
+      answers: input.answers,
+      submittedAt: new Date(),
+    });
+  }
+
+  static reconstitute(props: ResponseProps): ResponseAggregate {
+    return new ResponseAggregate(props);
+  }
+
+  get id(): ResponseId {
+    return this.props.id;
+  }
+
+  get formId(): string {
+    return this.props.formId;
+  }
+
+  get organizationId(): string {
+    return this.props.organizationId;
+  }
+
+  get answers(): Answer[] {
+    return this.props.answers;
+  }
+
+  get submittedAt(): Date {
+    return this.props.submittedAt;
+  }
+}

--- a/formix-backend/src/modules/responses/domain/aggregate/value-objects/response-email-id.vo.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/value-objects/response-email-id.vo.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'crypto';
+
+export class ResponseEmailId {
+  private constructor(private readonly value: string) {}
+
+  static create(): ResponseEmailId {
+    return new ResponseEmailId(randomUUID());
+  }
+
+  static from(value: string): ResponseEmailId {
+    if (!value?.trim()) throw new Error('Invalid ResponseEmailId');
+    return new ResponseEmailId(value);
+  }
+
+  getValue(): string {
+    return this.value;
+  }
+
+  equals(other: ResponseEmailId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/formix-backend/src/modules/responses/domain/aggregate/value-objects/response-id.vo.ts
+++ b/formix-backend/src/modules/responses/domain/aggregate/value-objects/response-id.vo.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'crypto';
+
+export class ResponseId {
+  private constructor(private readonly value: string) {}
+
+  static create(): ResponseId {
+    return new ResponseId(randomUUID());
+  }
+
+  static from(value: string): ResponseId {
+    if (!value?.trim()) throw new Error('Invalid ResponseId');
+    return new ResponseId(value);
+  }
+
+  getValue(): string {
+    return this.value;
+  }
+
+  equals(other: ResponseId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/formix-backend/src/modules/responses/domain/repositories/response-email.repository.ts
+++ b/formix-backend/src/modules/responses/domain/repositories/response-email.repository.ts
@@ -1,0 +1,9 @@
+import { ResponseEmailAggregate } from '../aggregate/response-email.aggregate';
+
+export interface IResponseEmailRepository {
+  save(responseEmail: ResponseEmailAggregate): Promise<void>;
+  existsByFormIdAndEmailHash(formId: string, emailHash: string): Promise<boolean>;
+  deleteByFormId(formId: string): Promise<void>;
+}
+
+export const RESPONSE_EMAIL_REPOSITORY = Symbol('RESPONSE_EMAIL_REPOSITORY');

--- a/formix-backend/src/modules/responses/domain/repositories/response.repository.ts
+++ b/formix-backend/src/modules/responses/domain/repositories/response.repository.ts
@@ -1,0 +1,16 @@
+import { ResponseAggregate } from '../aggregate/response.aggregate';
+import { Output } from '@shared/output';
+
+export interface FindByFormIdOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface IResponseRepository {
+  save(response: ResponseAggregate): Promise<void>;
+  findByFormId(formId: string, options?: FindByFormIdOptions): Promise<ResponseAggregate[]>;
+  countByFormId(formId: string): Promise<number>;
+  deleteByFormId(formId: string): Promise<void>;
+}
+
+export const RESPONSE_REPOSITORY = Symbol('RESPONSE_REPOSITORY');

--- a/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.spec.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.spec.ts
@@ -1,0 +1,107 @@
+import { ListResponsesUseCase } from './list-responses.usecase';
+import { IFormRepository } from '@modules/forms/domain/repositories/form.repository';
+import { IResponseRepository } from '../repositories/response.repository';
+import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
+import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
+import { FormStatus } from '@modules/forms/domain/aggregate/value-objects/form-status.vo';
+import { PublicToken } from '@modules/forms/domain/aggregate/value-objects/public-token.vo';
+import { ResponseAggregate } from '../aggregate/response.aggregate';
+import { Output } from '@shared/output';
+
+describe('ListResponsesUseCase', () => {
+  let useCase: ListResponsesUseCase;
+  let formRepo: jest.Mocked<IFormRepository>;
+  let responseRepo: jest.Mocked<IResponseRepository>;
+
+  const organizationId = 'org-123';
+
+  const makeForm = (orgId = organizationId) =>
+    FormAggregate.reconstitute({
+      id: FormId.create(),
+      organizationId: orgId,
+      createdBy: 'user-1',
+      title: 'Test Form',
+      publicToken: PublicToken.from('token-123'),
+      settings: { allowMultipleResponses: false, allowedEmailDomains: [] },
+      status: FormStatus.active(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+  const makeResponse = (formId: string) =>
+    ResponseAggregate.create({
+      formId,
+      organizationId,
+      answers: [{ questionId: 'q-1', value: 'hello' }],
+    });
+
+  beforeEach(() => {
+    formRepo = {
+      findById: jest.fn(),
+      findByPublicToken: jest.fn(),
+      findByOrganizationId: jest.fn(),
+      save: jest.fn(),
+      delete: jest.fn(),
+    };
+    responseRepo = {
+      save: jest.fn(),
+      findByFormId: jest.fn(),
+      countByFormId: jest.fn(),
+      deleteByFormId: jest.fn(),
+    };
+
+    useCase = new ListResponsesUseCase(formRepo, responseRepo);
+  });
+
+  it('should return paginated responses for valid form', async () => {
+    const form = makeForm();
+    const formId = form.id.getValue();
+    const response = makeResponse(formId);
+
+    formRepo.findById.mockResolvedValue(Output.ok(form));
+    responseRepo.findByFormId.mockResolvedValue([response]);
+    responseRepo.countByFormId.mockResolvedValue(1);
+
+    const result = await useCase.execute({ organizationId, formId, offset: 0, limit: 20 });
+
+    expect(result.isFailure).toBe(false);
+    expect(result.value.responses).toHaveLength(1);
+    expect(result.value.total).toBe(1);
+    expect(result.value.offset).toBe(0);
+    expect(result.value.limit).toBe(20);
+  });
+
+  it('should return 404 if form does not exist', async () => {
+    formRepo.findById.mockResolvedValue(Output.fail('Form not found'));
+
+    const result = await useCase.execute({ organizationId, formId: 'no-form' });
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('not found');
+  });
+
+  it('should return 403 if form belongs to another org', async () => {
+    const form = makeForm('other-org');
+    formRepo.findById.mockResolvedValue(Output.ok(form));
+
+    const result = await useCase.execute({ organizationId, formId: form.id.getValue() });
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('Forbidden');
+  });
+
+  it('should confirm no email/hash in responses', async () => {
+    const form = makeForm();
+    const formId = form.id.getValue();
+    const response = makeResponse(formId);
+
+    formRepo.findById.mockResolvedValue(Output.ok(form));
+    responseRepo.findByFormId.mockResolvedValue([response]);
+    responseRepo.countByFormId.mockResolvedValue(1);
+
+    const result = await useCase.execute({ organizationId, formId });
+
+    const responseItem = result.value.responses[0];
+    expect(responseItem).not.toHaveProperty('email');
+    expect(responseItem).not.toHaveProperty('emailHash');
+    expect(responseItem).not.toHaveProperty('userId');
+  });
+});

--- a/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Output } from '@shared/output';
+import { IFormRepository, FORM_REPOSITORY } from '@modules/forms/domain/repositories/form.repository';
+import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
+import { IResponseRepository, RESPONSE_REPOSITORY } from '../repositories/response.repository';
+import { Answer } from '../aggregate/response.aggregate';
+
+export interface ListResponsesInput {
+  organizationId: string;
+  formId: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface ResponseDto {
+  id: string;
+  answers: Answer[];
+  submittedAt: Date;
+}
+
+export interface ListResponsesOutput {
+  responses: ResponseDto[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+@Injectable()
+export class ListResponsesUseCase {
+  constructor(
+    @Inject(FORM_REPOSITORY) private readonly formRepository: IFormRepository,
+    @Inject(RESPONSE_REPOSITORY) private readonly responseRepository: IResponseRepository,
+  ) {}
+
+  async execute(input: ListResponsesInput): Promise<Output<ListResponsesOutput>> {
+    let formId: FormId;
+    try {
+      formId = FormId.from(input.formId);
+    } catch {
+      return Output.fail('Form not found');
+    }
+
+    const formResult = await this.formRepository.findById(formId);
+    if (formResult.isFailure) return Output.fail('Form not found');
+
+    const form = formResult.value;
+    if (form.organizationId !== input.organizationId) {
+      return Output.fail('Forbidden');
+    }
+
+    const offset = input.offset ?? 0;
+    const limit = input.limit ?? 20;
+
+    const [responses, total] = await Promise.all([
+      this.responseRepository.findByFormId(input.formId, { offset, limit }),
+      this.responseRepository.countByFormId(input.formId),
+    ]);
+
+    return Output.ok({
+      responses: responses.map(r => ({
+        id: r.id.getValue(),
+        answers: r.answers,
+        submittedAt: r.submittedAt,
+      })),
+      total,
+      offset,
+      limit,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.spec.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.spec.ts
@@ -1,0 +1,239 @@
+import { SubmitResponseUseCase, SubmitResponseInput } from './submit-response.usecase';
+import { IFormRepository } from '@modules/forms/domain/repositories/form.repository';
+import { IQuestionRepository } from '@modules/forms/domain/repositories/question.repository';
+import { IResponseRepository } from '../repositories/response.repository';
+import { IResponseEmailRepository } from '../repositories/response-email.repository';
+import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
+import { PublicToken } from '@modules/forms/domain/aggregate/value-objects/public-token.vo';
+import { FormStatus } from '@modules/forms/domain/aggregate/value-objects/form-status.vo';
+import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
+import { QuestionEntity } from '@modules/forms/domain/aggregate/question.entity';
+import { QuestionId } from '@modules/forms/domain/aggregate/value-objects/question-id.vo';
+import { Output } from '@shared/output';
+
+const makeActiveForm = (overrides: Partial<{
+  allowMultipleResponses: boolean;
+  allowedEmailDomains: string[];
+  expiresAt: Date;
+  maxResponses: number;
+}> = {}) => {
+  const form = FormAggregate.reconstitute({
+    id: FormId.create(),
+    organizationId: 'org-123',
+    createdBy: 'user-1',
+    title: 'Test Form',
+    publicToken: PublicToken.from('test-token'),
+    settings: {
+      allowMultipleResponses: overrides.allowMultipleResponses ?? false,
+      allowedEmailDomains: overrides.allowedEmailDomains ?? [],
+      expiresAt: overrides.expiresAt,
+      maxResponses: overrides.maxResponses,
+    },
+    status: FormStatus.active(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  return form;
+};
+
+const makeQuestion = (formId: string, type = 'text', required = true, options?: string[]) =>
+  QuestionEntity.reconstitute({
+    id: QuestionId.create(),
+    formId,
+    organizationId: 'org-123',
+    type: { getValue: () => type, requiresOptions: () => ['radio', 'checkbox', 'dropdown'].includes(type), equals: () => false } as any,
+    label: 'Question',
+    required,
+    order: 1,
+    options,
+    createdAt: new Date(),
+  });
+
+describe('SubmitResponseUseCase', () => {
+  let useCase: SubmitResponseUseCase;
+  let formRepo: jest.Mocked<IFormRepository>;
+  let questionRepo: jest.Mocked<IQuestionRepository>;
+  let responseRepo: jest.Mocked<IResponseRepository>;
+  let responseEmailRepo: jest.Mocked<IResponseEmailRepository>;
+
+  const publicToken = 'test-token';
+  const email = 'user@example.com';
+
+  beforeEach(() => {
+    formRepo = {
+      findByPublicToken: jest.fn(),
+      save: jest.fn(),
+      findById: jest.fn(),
+      findByOrganizationId: jest.fn(),
+      delete: jest.fn(),
+    };
+    questionRepo = {
+      findByFormId: jest.fn(),
+      findByFormIdOrdered: jest.fn(),
+      save: jest.fn(),
+      findById: jest.fn(),
+      countByFormId: jest.fn(),
+      delete: jest.fn(),
+      deleteByFormId: jest.fn(),
+    };
+    responseRepo = {
+      save: jest.fn(),
+      findByFormId: jest.fn(),
+      countByFormId: jest.fn(),
+      deleteByFormId: jest.fn(),
+    };
+    responseEmailRepo = {
+      save: jest.fn(),
+      existsByFormIdAndEmailHash: jest.fn(),
+      deleteByFormId: jest.fn(),
+    };
+
+    useCase = new SubmitResponseUseCase(formRepo, questionRepo, responseRepo, responseEmailRepo);
+  });
+
+  const validInput: SubmitResponseInput = {
+    publicToken,
+    email,
+    answers: [],
+  };
+
+  it('should return 404 if form not found', async () => {
+    formRepo.findByPublicToken.mockResolvedValue(Output.fail('Form not found'));
+    const result = await useCase.execute(validInput);
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('not found');
+  });
+
+  it('should return error if form is not active', async () => {
+    const form = FormAggregate.reconstitute({
+      id: FormId.create(),
+      organizationId: 'org-123',
+      createdBy: 'user-1',
+      title: 'Test',
+      publicToken: PublicToken.from(publicToken),
+      settings: { allowMultipleResponses: false, allowedEmailDomains: [] },
+      status: FormStatus.from('draft'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    questionRepo.findByFormIdOrdered.mockResolvedValue([]);
+    responseRepo.countByFormId.mockResolvedValue(0);
+    responseEmailRepo.existsByFormIdAndEmailHash.mockResolvedValue(false);
+
+    const result = await useCase.execute(validInput);
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('not active');
+  });
+
+  it('should return error if form is expired by date', async () => {
+    const form = makeActiveForm({ expiresAt: new Date(Date.now() - 1000) });
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+
+    const result = await useCase.execute(validInput);
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('expired');
+    expect(formRepo.save).toHaveBeenCalled();
+  });
+
+  it('should return error if maxResponses reached', async () => {
+    const form = makeActiveForm({ maxResponses: 5 });
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(5);
+
+    const result = await useCase.execute(validInput);
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('limit');
+    expect(formRepo.save).toHaveBeenCalled();
+  });
+
+  it('should return 403 if email domain not allowed', async () => {
+    const form = makeActiveForm({ allowedEmailDomains: ['company.com'] });
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+
+    const result = await useCase.execute({ ...validInput, email: 'user@other.com' });
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('domain');
+  });
+
+  it('should return 409 if duplicate submission not allowed', async () => {
+    const form = makeActiveForm({ allowMultipleResponses: false });
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+    responseEmailRepo.existsByFormIdAndEmailHash.mockResolvedValue(true);
+    questionRepo.findByFormIdOrdered.mockResolvedValue([]);
+
+    const result = await useCase.execute(validInput);
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('already responded');
+  });
+
+  it('should return 400 if required question not answered', async () => {
+    const form = makeActiveForm();
+    const qId = QuestionId.create();
+    const question = makeQuestion(form.id.getValue(), 'text', true);
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+    responseEmailRepo.existsByFormIdAndEmailHash.mockResolvedValue(false);
+    questionRepo.findByFormIdOrdered.mockResolvedValue([question]);
+
+    const result = await useCase.execute({ ...validInput, answers: [] });
+    expect(result.isFailure).toBe(true);
+    expect(result.errorMessage).toContain('required');
+  });
+
+  it('should save response WITHOUT email or hash, and save email hash SEPARATELY', async () => {
+    const form = makeActiveForm();
+    const question = makeQuestion(form.id.getValue(), 'text', true);
+    const questionId = question.id.getValue();
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+    responseEmailRepo.existsByFormIdAndEmailHash.mockResolvedValue(false);
+    questionRepo.findByFormIdOrdered.mockResolvedValue([question]);
+    responseRepo.save.mockResolvedValue(undefined);
+    responseEmailRepo.save.mockResolvedValue(undefined);
+
+    const result = await useCase.execute({
+      publicToken,
+      email,
+      answers: [{ questionId, value: 'My answer' }],
+    });
+
+    expect(result.isFailure).toBe(false);
+    expect(responseRepo.save).toHaveBeenCalledTimes(1);
+    expect(responseEmailRepo.save).toHaveBeenCalledTimes(1);
+
+    const savedResponse = responseRepo.save.mock.calls[0][0];
+    // Response must NOT contain email or hash
+    const responseKeys = Object.keys(savedResponse);
+    expect(responseKeys).not.toContain('email');
+    expect(responseKeys).not.toContain('emailHash');
+
+    const savedEmailRecord = responseEmailRepo.save.mock.calls[0][0];
+    // EmailRecord must NOT reference responseId
+    const emailRecordKeys = Object.keys(savedEmailRecord);
+    expect(emailRecordKeys).not.toContain('responseId');
+  });
+
+  it('should allow submission when allowMultipleResponses is true', async () => {
+    const form = makeActiveForm({ allowMultipleResponses: true });
+    const question = makeQuestion(form.id.getValue(), 'text', true);
+    const questionId = question.id.getValue();
+    formRepo.findByPublicToken.mockResolvedValue(Output.ok(form));
+    responseRepo.countByFormId.mockResolvedValue(0);
+    questionRepo.findByFormIdOrdered.mockResolvedValue([question]);
+    responseRepo.save.mockResolvedValue(undefined);
+    responseEmailRepo.save.mockResolvedValue(undefined);
+
+    const result = await useCase.execute({
+      publicToken,
+      email,
+      answers: [{ questionId, value: 'text' }],
+    });
+
+    expect(result.isFailure).toBe(false);
+    expect(responseEmailRepo.existsByFormIdAndEmailHash).not.toHaveBeenCalled();
+  });
+});

--- a/formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/submit-response.usecase.ts
@@ -1,0 +1,167 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { Output } from '@shared/output';
+import { IFormRepository, FORM_REPOSITORY } from '@modules/forms/domain/repositories/form.repository';
+import { IQuestionRepository, QUESTION_REPOSITORY } from '@modules/forms/domain/repositories/question.repository';
+import { IResponseRepository, RESPONSE_REPOSITORY } from '../repositories/response.repository';
+import { IResponseEmailRepository, RESPONSE_EMAIL_REPOSITORY } from '../repositories/response-email.repository';
+import { ResponseAggregate, Answer } from '../aggregate/response.aggregate';
+import { ResponseEmailAggregate } from '../aggregate/response-email.aggregate';
+
+export interface SubmitResponseInput {
+  publicToken: string;
+  email: string;
+  answers: Answer[];
+}
+
+export interface SubmitResponseOutput {
+  submitted: boolean;
+}
+
+@Injectable()
+export class SubmitResponseUseCase {
+  constructor(
+    @Inject(FORM_REPOSITORY) private readonly formRepository: IFormRepository,
+    @Inject(QUESTION_REPOSITORY) private readonly questionRepository: IQuestionRepository,
+    @Inject(RESPONSE_REPOSITORY) private readonly responseRepository: IResponseRepository,
+    @Inject(RESPONSE_EMAIL_REPOSITORY) private readonly responseEmailRepository: IResponseEmailRepository,
+  ) {}
+
+  async execute(input: SubmitResponseInput): Promise<Output<SubmitResponseOutput>> {
+    // Step 1: Find form by publicToken
+    const formResult = await this.formRepository.findByPublicToken(input.publicToken);
+    if (formResult.isFailure) return Output.fail('Form not found');
+    const form = formResult.value;
+
+    // Step 2: Check form status
+    if (!form.status.isActive()) return Output.fail('Form is not active');
+
+    // Step 3: Check expiration by date
+    if (form.settings.expiresAt && new Date() > form.settings.expiresAt) {
+      form.close();
+      await this.formRepository.save(form);
+      return Output.fail('Form has expired');
+    }
+
+    // Step 4: Check maxResponses
+    if (form.settings.maxResponses !== undefined) {
+      const count = await this.responseRepository.countByFormId(form.id.getValue());
+      if (count >= form.settings.maxResponses) {
+        form.close();
+        await this.formRepository.save(form);
+        return Output.fail('Form has reached response limit');
+      }
+    }
+
+    // Step 5: Check allowed email domains
+    const { allowedEmailDomains } = form.settings;
+    if (allowedEmailDomains.length > 0) {
+      const emailDomain = input.email.toLowerCase().split('@')[1];
+      if (!allowedEmailDomains.includes(emailDomain)) {
+        return Output.fail('Email domain not allowed');
+      }
+    }
+
+    // Step 6: Compute email hash
+    const emailHash = createHash('sha256').update(input.email.toLowerCase()).digest('hex');
+
+    // Step 7: Check duplicity
+    if (!form.settings.allowMultipleResponses) {
+      const exists = await this.responseEmailRepository.existsByFormIdAndEmailHash(
+        form.id.getValue(),
+        emailHash,
+      );
+      if (exists) return Output.fail('You have already responded to this form');
+    }
+
+    // Step 8: Fetch questions
+    const questions = await this.questionRepository.findByFormIdOrdered(form.id.getValue());
+
+    // Step 9: Validate answers
+    const answersMap = new Map(input.answers.map(a => [a.questionId, a.value]));
+    for (const question of questions) {
+      const value = answersMap.get(question.id.getValue());
+      const type = question.type.getValue();
+
+      // Required check
+      if (question.required && (value === undefined || value === null || value === '')) {
+        return Output.fail(`Question "${question.label}" is required`);
+      }
+
+      if (value === undefined || value === null) continue;
+
+      // Type-specific validation
+      if (type === 'number') {
+        const num = Number(value);
+        if (isNaN(num)) return Output.fail(`Question "${question.label}" must be a number`);
+        if (question.validation?.min !== undefined && num < question.validation.min) {
+          return Output.fail(`Question "${question.label}" must be at least ${question.validation.min}`);
+        }
+        if (question.validation?.max !== undefined && num > question.validation.max) {
+          return Output.fail(`Question "${question.label}" must be at most ${question.validation.max}`);
+        }
+      }
+
+      if (type === 'email') {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (typeof value !== 'string' || !emailRegex.test(value)) {
+          return Output.fail(`Question "${question.label}" must be a valid email`);
+        }
+      }
+
+      if (type === 'radio' || type === 'dropdown') {
+        if (!question.options?.includes(value as string)) {
+          return Output.fail(`Question "${question.label}" has an invalid option`);
+        }
+      }
+
+      if (type === 'checkbox') {
+        if (!Array.isArray(value)) {
+          return Output.fail(`Question "${question.label}" must be an array of options`);
+        }
+        const invalidOptions = (value as string[]).filter(v => !question.options?.includes(v));
+        if (invalidOptions.length > 0) {
+          return Output.fail(`Question "${question.label}" has invalid options`);
+        }
+      }
+
+      if (type === 'date') {
+        const date = new Date(value as string);
+        if (isNaN(date.getTime())) {
+          return Output.fail(`Question "${question.label}" must be a valid date`);
+        }
+      }
+
+      if (type === 'rating') {
+        const num = Number(value);
+        const max = question.validation?.max ?? 5;
+        if (isNaN(num) || num < 1 || num > max) {
+          return Output.fail(`Question "${question.label}" rating must be between 1 and ${max}`);
+        }
+      }
+
+      if (type === 'text' || type === 'textarea') {
+        if (question.validation?.pattern) {
+          const regex = new RegExp(question.validation.pattern);
+          if (!regex.test(value as string)) {
+            return Output.fail(`Question "${question.label}" does not match required pattern`);
+          }
+        }
+      }
+    }
+
+    // Step 10: Save response WITHOUT email or hash
+    const response = ResponseAggregate.create({
+      formId: form.id.getValue(),
+      organizationId: form.organizationId,
+      answers: input.answers,
+    });
+    await this.responseRepository.save(response);
+
+    // Step 11: Save email hash SEPARATELY — no reference to response
+    const responseEmail = ResponseEmailAggregate.create(form.id.getValue(), emailHash);
+    await this.responseEmailRepository.save(responseEmail);
+
+    return Output.ok({ submitted: true });
+  }
+}

--- a/formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts
@@ -1,0 +1,193 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule } from '@nestjs/config';
+import mongoose from 'mongoose';
+import * as request from 'supertest';
+import { ResponsesController } from './responses.controller';
+import { SubmitResponseUseCase } from '@modules/responses/domain/usecases/submit-response.usecase';
+import { ListResponsesUseCase } from '@modules/responses/domain/usecases/list-responses.usecase';
+import { MongoResponseRepository } from '../repositories/mongo-response.repository';
+import { MongoResponseEmailRepository } from '../repositories/mongo-response-email.repository';
+import { MongoFormRepository } from '@modules/forms/infra/repositories/mongo-form.repository';
+import { MongoQuestionRepository } from '@modules/forms/infra/repositories/mongo-question.repository';
+import { RESPONSE_REPOSITORY } from '@modules/responses/domain/repositories/response.repository';
+import { RESPONSE_EMAIL_REPOSITORY } from '@modules/responses/domain/repositories/response-email.repository';
+import { FORM_REPOSITORY, IFormRepository } from '@modules/forms/domain/repositories/form.repository';
+import { QUESTION_REPOSITORY } from '@modules/forms/domain/repositories/question.repository';
+import { ResponseSchemaClass, ResponseSchema } from '../schemas/response.schema';
+import { ResponseEmailSchemaClass, ResponseEmailSchema } from '../schemas/response-email.schema';
+import { FormSchemaClass, FormSchema } from '@modules/forms/infra/schemas/form.schema';
+import { QuestionSchemaClass, QuestionSchema } from '@modules/forms/infra/schemas/question.schema';
+import { JwtStrategy } from '@modules/auth/infra/strategies/jwt.strategy';
+import { JwtAuthGuard } from '@modules/auth/infra/guards/jwt-auth.guard';
+import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
+import { PublicToken } from '@modules/forms/domain/aggregate/value-objects/public-token.vo';
+
+const TEST_SECRET = 'default-secret';
+
+describe('ResponsesController (integration)', () => {
+  let mongod: MongoMemoryServer;
+  let app: INestApplication;
+  let jwtService: JwtService;
+  let userToken: string;
+  let formRepo: IFormRepository;
+  const organizationId = 'org-test-123';
+  const userId = 'user-test-456';
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const uri = mongod.getUri();
+
+    const testModule: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
+        MongooseModule.forRoot(uri),
+        MongooseModule.forFeature([
+          { name: ResponseSchemaClass.name, schema: ResponseSchema },
+          { name: ResponseEmailSchemaClass.name, schema: ResponseEmailSchema },
+          { name: FormSchemaClass.name, schema: FormSchema },
+          { name: QuestionSchemaClass.name, schema: QuestionSchema },
+        ]),
+        PassportModule.register({ defaultStrategy: 'jwt' }),
+        JwtModule.register({ secret: TEST_SECRET, signOptions: { expiresIn: '15m' } }),
+      ],
+      controllers: [ResponsesController],
+      providers: [
+        SubmitResponseUseCase,
+        ListResponsesUseCase,
+        { provide: RESPONSE_REPOSITORY, useClass: MongoResponseRepository },
+        { provide: RESPONSE_EMAIL_REPOSITORY, useClass: MongoResponseEmailRepository },
+        { provide: FORM_REPOSITORY, useClass: MongoFormRepository },
+        { provide: QUESTION_REPOSITORY, useClass: MongoQuestionRepository },
+        JwtStrategy,
+        JwtAuthGuard,
+        { provide: APP_GUARD, useClass: JwtAuthGuard },
+      ],
+    }).compile();
+
+    app = testModule.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    jwtService = testModule.get(JwtService);
+    userToken = jwtService.sign({ sub: userId, organizationId, role: 'admin' });
+    formRepo = testModule.get(FORM_REPOSITORY);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  describe('POST /responses/:publicToken', () => {
+    it('should return 201 for valid submission', async () => {
+      // Create and publish a form
+      const form = FormAggregate.create({ organizationId, createdBy: userId, title: 'Public Form' });
+      form.publish(PublicToken.generate());
+      await formRepo.save(form);
+      const token = form.publicToken!.getValue();
+
+      const res = await request(app.getHttpServer())
+        .post(`/responses/${token}`)
+        .send({ email: 'test@example.com', answers: [] });
+
+      expect(res.status).toBe(201);
+      expect(res.body.submitted).toBe(true);
+    });
+
+    it('should return 404 for unknown publicToken', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/responses/unknown-token-xyz')
+        .send({ email: 'test@example.com', answers: [] });
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 409 on duplicate submission', async () => {
+      const form = FormAggregate.create({ organizationId, createdBy: userId, title: 'No Dup Form' });
+      form.publish(PublicToken.generate());
+      await formRepo.save(form);
+      const token = form.publicToken!.getValue();
+
+      await request(app.getHttpServer())
+        .post(`/responses/${token}`)
+        .send({ email: 'dup@example.com', answers: [] });
+
+      const res = await request(app.getHttpServer())
+        .post(`/responses/${token}`)
+        .send({ email: 'dup@example.com', answers: [] });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('should not require authentication (public route)', async () => {
+      const form = FormAggregate.create({ organizationId, createdBy: userId, title: 'Public No Auth' });
+      form.publish(PublicToken.generate());
+      await formRepo.save(form);
+      const token = form.publicToken!.getValue();
+
+      const res = await request(app.getHttpServer())
+        .post(`/responses/${token}`)
+        .send({ email: 'noauth@example.com', answers: [] });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('GET /forms/:id/responses', () => {
+    it('should return paginated responses (200)', async () => {
+      const form = FormAggregate.create({ organizationId, createdBy: userId, title: 'Responses Form' });
+      form.publish(PublicToken.generate());
+      await formRepo.save(form);
+      const formId = form.id.getValue();
+      const token = form.publicToken!.getValue();
+
+      // Submit a response first
+      await request(app.getHttpServer())
+        .post(`/responses/${token}`)
+        .send({ email: 'view@example.com', answers: [] });
+
+      const res = await request(app.getHttpServer())
+        .get(`/forms/${formId}/responses`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.responses).toBeDefined();
+      expect(res.body.total).toBeGreaterThanOrEqual(1);
+      expect(res.body.offset).toBe(0);
+      expect(res.body.limit).toBe(20);
+    });
+
+    it('should return 404 for unknown formId', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/forms/unknown-form-id/responses')
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should return 401 without auth', async () => {
+      const res = await request(app.getHttpServer()).get('/forms/some-id/responses');
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 403 for form belonging to another org', async () => {
+      const form = FormAggregate.create({ organizationId: 'other-org', createdBy: userId, title: 'Other Form' });
+      form.publish(PublicToken.generate());
+      await formRepo.save(form);
+      const formId = form.id.getValue();
+
+      const res = await request(app.getHttpServer())
+        .get(`/forms/${formId}/responses`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/responses.controller.test.ts
@@ -11,6 +11,7 @@ import * as request from 'supertest';
 import { ResponsesController } from './responses.controller';
 import { SubmitResponseUseCase } from '@modules/responses/domain/usecases/submit-response.usecase';
 import { ListResponsesUseCase } from '@modules/responses/domain/usecases/list-responses.usecase';
+import { GetPublicFormUseCase } from '@modules/forms/domain/usecases/get-public-form.usecase';
 import { MongoResponseRepository } from '../repositories/mongo-response.repository';
 import { MongoResponseEmailRepository } from '../repositories/mongo-response-email.repository';
 import { MongoFormRepository } from '@modules/forms/infra/repositories/mongo-form.repository';
@@ -60,6 +61,7 @@ describe('ResponsesController (integration)', () => {
       providers: [
         SubmitResponseUseCase,
         ListResponsesUseCase,
+        GetPublicFormUseCase,
         { provide: RESPONSE_REPOSITORY, useClass: MongoResponseRepository },
         { provide: RESPONSE_EMAIL_REPOSITORY, useClass: MongoResponseEmailRepository },
         { provide: FORM_REPOSITORY, useClass: MongoFormRepository },

--- a/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
@@ -23,6 +23,7 @@ import { Public } from '@modules/auth/infra/decorators/public.decorator';
 import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
 import { SubmitResponseUseCase } from '@modules/responses/domain/usecases/submit-response.usecase';
 import { ListResponsesUseCase } from '@modules/responses/domain/usecases/list-responses.usecase';
+import { GetPublicFormUseCase } from '@modules/forms/domain/usecases/get-public-form.usecase';
 import { SubmitResponseDto, SubmitResponseResponseDto } from './submit-response.dto';
 
 @ApiTags('responses')
@@ -31,7 +32,20 @@ export class ResponsesController {
   constructor(
     private readonly submitResponseUseCase: SubmitResponseUseCase,
     private readonly listResponsesUseCase: ListResponsesUseCase,
+    private readonly getPublicFormUseCase: GetPublicFormUseCase,
   ) {}
+
+  @Get('forms/public/:publicToken')
+  @Public()
+  @ApiOperation({ summary: 'Get public form data by public token' })
+  @ApiParam({ name: 'publicToken', description: 'Public token of the form' })
+  @ApiResponse({ status: 200, description: 'Public form data with questions' })
+  @ApiResponse({ status: 404, description: 'Form not found' })
+  async getPublicForm(@Param('publicToken') publicToken: string) {
+    const output = await this.getPublicFormUseCase.execute(publicToken);
+    if (output.isFailure) throw new NotFoundException(output.errorMessage);
+    return output.value;
+  }
 
   @Post('responses/:publicToken')
   @Public()

--- a/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
@@ -1,0 +1,98 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  ForbiddenException,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Public } from '@modules/auth/infra/decorators/public.decorator';
+import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
+import { SubmitResponseUseCase } from '@modules/responses/domain/usecases/submit-response.usecase';
+import { ListResponsesUseCase } from '@modules/responses/domain/usecases/list-responses.usecase';
+import { SubmitResponseDto, SubmitResponseResponseDto } from './submit-response.dto';
+
+@ApiTags('responses')
+@Controller()
+export class ResponsesController {
+  constructor(
+    private readonly submitResponseUseCase: SubmitResponseUseCase,
+    private readonly listResponsesUseCase: ListResponsesUseCase,
+  ) {}
+
+  @Post('responses/:publicToken')
+  @Public()
+  @ApiOperation({ summary: 'Submit a response to a public form' })
+  @ApiParam({ name: 'publicToken', description: 'Public token of the form' })
+  @ApiBody({ type: SubmitResponseDto })
+  @ApiResponse({ status: 201, description: 'Response submitted successfully', type: SubmitResponseResponseDto })
+  @ApiResponse({ status: 400, description: 'Form not active, expired, or invalid answers' })
+  @ApiResponse({ status: 403, description: 'Email domain not allowed' })
+  @ApiResponse({ status: 404, description: 'Form not found' })
+  @ApiResponse({ status: 409, description: 'Already responded to this form' })
+  async submitResponse(
+    @Param('publicToken') publicToken: string,
+    @Body() dto: SubmitResponseDto,
+  ): Promise<SubmitResponseResponseDto> {
+    const output = await this.submitResponseUseCase.execute({
+      publicToken,
+      email: dto.email,
+      answers: dto.answers,
+    });
+
+    if (output.isFailure) {
+      const msg = output.errorMessage;
+      if (msg.includes('not found')) throw new NotFoundException(msg);
+      if (msg.includes('domain')) throw new ForbiddenException(msg);
+      if (msg.includes('already responded')) throw new ConflictException(msg);
+      throw new BadRequestException(msg);
+    }
+
+    return output.value;
+  }
+
+  @Get('forms/:id/responses')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'List paginated responses for a form' })
+  @ApiParam({ name: 'id', description: 'Form ID' })
+  @ApiQuery({ name: 'offset', required: false, description: 'Pagination offset (default: 0)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Number of results (default: 20)' })
+  @ApiResponse({ status: 200, description: 'Paginated list of responses' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — form belongs to another organization' })
+  @ApiResponse({ status: 404, description: 'Form not found' })
+  async listResponses(
+    @Param('id') formId: string,
+    @CurrentUser() user: JwtPayload,
+    @Query('offset') offset?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const output = await this.listResponsesUseCase.execute({
+      organizationId: user.organizationId,
+      formId,
+      offset: offset ? parseInt(offset, 10) : 0,
+      limit: limit ? parseInt(limit, 10) : 20,
+    });
+
+    if (output.isFailure) {
+      const msg = output.errorMessage;
+      if (msg.includes('Forbidden')) throw new ForbiddenException(msg);
+      throw new NotFoundException(msg);
+    }
+
+    return output.value;
+  }
+}

--- a/formix-backend/src/modules/responses/infra/controllers/submit-response.dto.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/submit-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsEmail, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class AnswerDto {
+  @ApiProperty({ example: 'uuid-question-id', description: 'Question ID' })
+  @IsString()
+  questionId: string;
+
+  @ApiProperty({ example: 'My answer', description: 'Answer value (any type depending on question type)' })
+  value: unknown;
+}
+
+export class SubmitResponseDto {
+  @ApiProperty({ example: 'user@example.com', description: 'Email of the respondent' })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ type: [AnswerDto], description: 'List of answers' })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AnswerDto)
+  answers: AnswerDto[];
+}
+
+export class SubmitResponseResponseDto {
+  @ApiProperty({ example: true })
+  submitted: boolean;
+}

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { MongoResponseEmailRepository } from './mongo-response-email.repository';
+import { ResponseEmailSchemaClass, ResponseEmailSchema } from '../schemas/response-email.schema';
+import { ResponseEmailAggregate } from '@modules/responses/domain/aggregate/response-email.aggregate';
+
+describe('MongoResponseEmailRepository (integration)', () => {
+  let mongod: MongoMemoryServer;
+  let repo: MongoResponseEmailRepository;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot(mongod.getUri()),
+        MongooseModule.forFeature([
+          { name: ResponseEmailSchemaClass.name, schema: ResponseEmailSchema },
+        ]),
+      ],
+      providers: [MongoResponseEmailRepository],
+    }).compile();
+
+    repo = module.get(MongoResponseEmailRepository);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  it('should save and existsByFormIdAndEmailHash returns true', async () => {
+    const re = ResponseEmailAggregate.create('form-123', 'hash-abc');
+    await repo.save(re);
+    const exists = await repo.existsByFormIdAndEmailHash('form-123', 'hash-abc');
+    expect(exists).toBe(true);
+  });
+
+  it('should return false when not found', async () => {
+    const exists = await repo.existsByFormIdAndEmailHash('form-notexist', 'hash-xyz');
+    expect(exists).toBe(false);
+  });
+
+  it('should deleteByFormId', async () => {
+    const formId = 'form-delete-email';
+    await repo.save(ResponseEmailAggregate.create(formId, 'hash-1'));
+    await repo.save(ResponseEmailAggregate.create(formId, 'hash-2'));
+    await repo.deleteByFormId(formId);
+    const exists = await repo.existsByFormIdAndEmailHash(formId, 'hash-1');
+    expect(exists).toBe(false);
+  });
+
+  it('should not expose any data — existsByFormIdAndEmailHash returns only boolean', async () => {
+    const result = await repo.existsByFormIdAndEmailHash('some-form', 'some-hash');
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { IResponseEmailRepository } from '@modules/responses/domain/repositories/response-email.repository';
+import { ResponseEmailAggregate } from '@modules/responses/domain/aggregate/response-email.aggregate';
+import { ResponseEmailId } from '@modules/responses/domain/aggregate/value-objects/response-email-id.vo';
+import {
+  ResponseEmailDocument,
+  ResponseEmailSchemaClass,
+} from '../schemas/response-email.schema';
+
+@Injectable()
+export class MongoResponseEmailRepository implements IResponseEmailRepository {
+  constructor(
+    @InjectModel(ResponseEmailSchemaClass.name)
+    private readonly responseEmailModel: Model<ResponseEmailDocument>,
+  ) {}
+
+  async save(responseEmail: ResponseEmailAggregate): Promise<void> {
+    await this.responseEmailModel.findOneAndUpdate(
+      { _id: responseEmail.id.getValue() },
+      {
+        $set: {
+          formId: responseEmail.formId,
+          emailHash: responseEmail.emailHash,
+          respondedAt: responseEmail.respondedAt,
+        },
+        $setOnInsert: { _id: responseEmail.id.getValue() },
+      },
+      { upsert: true },
+    );
+  }
+
+  async existsByFormIdAndEmailHash(formId: string, emailHash: string): Promise<boolean> {
+    const count = await this.responseEmailModel.countDocuments({ formId, emailHash }).exec();
+    return count > 0;
+  }
+
+  async deleteByFormId(formId: string): Promise<void> {
+    await this.responseEmailModel.deleteMany({ formId }).exec();
+  }
+
+  private toEntity(doc: ResponseEmailDocument): ResponseEmailAggregate {
+    return ResponseEmailAggregate.reconstitute({
+      id: ResponseEmailId.from(doc._id as string),
+      formId: doc.formId,
+      emailHash: doc.emailHash,
+      respondedAt: doc.respondedAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.test.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.test.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MongooseModule } from '@nestjs/mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { MongoResponseRepository } from './mongo-response.repository';
+import { ResponseSchemaClass, ResponseSchema } from '../schemas/response.schema';
+import { ResponseAggregate } from '@modules/responses/domain/aggregate/response.aggregate';
+
+describe('MongoResponseRepository (integration)', () => {
+  let mongod: MongoMemoryServer;
+  let repo: MongoResponseRepository;
+
+  const makeResponse = (formId = 'form-123', orgId = 'org-123') =>
+    ResponseAggregate.create({
+      formId,
+      organizationId: orgId,
+      answers: [{ questionId: 'q-1', value: 'hello' }],
+    });
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot(mongod.getUri()),
+        MongooseModule.forFeature([{ name: ResponseSchemaClass.name, schema: ResponseSchema }]),
+      ],
+      providers: [MongoResponseRepository],
+    }).compile();
+
+    repo = module.get(MongoResponseRepository);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  it('should save and findByFormId', async () => {
+    const r = makeResponse('form-save-test');
+    await repo.save(r);
+    const results = await repo.findByFormId('form-save-test');
+    expect(results).toHaveLength(1);
+    expect(results[0].id.getValue()).toBe(r.id.getValue());
+    expect(results[0].answers[0].value).toBe('hello');
+  });
+
+  it('should findByFormId with pagination', async () => {
+    const formId = 'form-paginate';
+    await repo.save(makeResponse(formId));
+    await repo.save(makeResponse(formId));
+    await repo.save(makeResponse(formId));
+
+    const page1 = await repo.findByFormId(formId, { limit: 2, offset: 0 });
+    const page2 = await repo.findByFormId(formId, { limit: 2, offset: 2 });
+
+    expect(page1).toHaveLength(2);
+    expect(page2).toHaveLength(1);
+  });
+
+  it('should countByFormId', async () => {
+    const formId = 'form-count';
+    await repo.save(makeResponse(formId));
+    await repo.save(makeResponse(formId));
+    const count = await repo.countByFormId(formId);
+    expect(count).toBe(2);
+  });
+
+  it('should deleteByFormId', async () => {
+    const formId = 'form-delete';
+    await repo.save(makeResponse(formId));
+    await repo.save(makeResponse(formId));
+    await repo.deleteByFormId(formId);
+    const count = await repo.countByFormId(formId);
+    expect(count).toBe(0);
+  });
+});

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  IResponseRepository,
+  FindByFormIdOptions,
+} from '@modules/responses/domain/repositories/response.repository';
+import { ResponseAggregate } from '@modules/responses/domain/aggregate/response.aggregate';
+import { ResponseId } from '@modules/responses/domain/aggregate/value-objects/response-id.vo';
+import { ResponseDocument, ResponseSchemaClass } from '../schemas/response.schema';
+
+@Injectable()
+export class MongoResponseRepository implements IResponseRepository {
+  constructor(
+    @InjectModel(ResponseSchemaClass.name)
+    private readonly responseModel: Model<ResponseDocument>,
+  ) {}
+
+  async save(response: ResponseAggregate): Promise<void> {
+    await this.responseModel.findOneAndUpdate(
+      { _id: response.id.getValue() },
+      {
+        $set: {
+          formId: response.formId,
+          organizationId: response.organizationId,
+          answers: response.answers,
+          submittedAt: response.submittedAt,
+        },
+        $setOnInsert: { _id: response.id.getValue() },
+      },
+      { upsert: true },
+    );
+  }
+
+  async findByFormId(formId: string, options?: FindByFormIdOptions): Promise<ResponseAggregate[]> {
+    const limit = options?.limit ?? 20;
+    const offset = options?.offset ?? 0;
+
+    const docs = await this.responseModel
+      .find({ formId })
+      .sort({ submittedAt: -1 })
+      .skip(offset)
+      .limit(limit)
+      .exec();
+
+    return docs.map(this.toEntity);
+  }
+
+  async countByFormId(formId: string): Promise<number> {
+    return this.responseModel.countDocuments({ formId }).exec();
+  }
+
+  async deleteByFormId(formId: string): Promise<void> {
+    await this.responseModel.deleteMany({ formId }).exec();
+  }
+
+  private toEntity(doc: ResponseDocument): ResponseAggregate {
+    return ResponseAggregate.reconstitute({
+      id: ResponseId.from(doc._id as string),
+      formId: doc.formId,
+      organizationId: doc.organizationId,
+      answers: doc.answers,
+      submittedAt: doc.submittedAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/infra/schemas/response-email.schema.ts
+++ b/formix-backend/src/modules/responses/infra/schemas/response-email.schema.ts
@@ -1,0 +1,23 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type ResponseEmailDocument = HydratedDocument<ResponseEmailSchemaClass>;
+
+@Schema({ timestamps: false, collection: 'response_emails', _id: false })
+export class ResponseEmailSchemaClass {
+  @Prop({ type: String, required: true })
+  _id: string;
+
+  @Prop({ required: true })
+  formId: string;
+
+  @Prop({ required: true })
+  emailHash: string;
+
+  @Prop({ required: true, default: () => new Date() })
+  respondedAt: Date;
+}
+
+export const ResponseEmailSchema = SchemaFactory.createForClass(ResponseEmailSchemaClass);
+
+ResponseEmailSchema.index({ formId: 1, emailHash: 1 }, { unique: true });

--- a/formix-backend/src/modules/responses/infra/schemas/response.schema.ts
+++ b/formix-backend/src/modules/responses/infra/schemas/response.schema.ts
@@ -1,0 +1,32 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type ResponseDocument = HydratedDocument<ResponseSchemaClass>;
+
+@Schema({ timestamps: false, collection: 'responses', _id: false })
+export class ResponseSchemaClass {
+  @Prop({ type: String, required: true })
+  _id: string;
+
+  @Prop({ required: true })
+  formId: string;
+
+  @Prop({ required: true })
+  organizationId: string;
+
+  @Prop({
+    type: [{ questionId: String, value: Object }],
+    required: true,
+    default: [],
+  })
+  answers: { questionId: string; value: unknown }[];
+
+  @Prop({ required: true, default: () => new Date() })
+  submittedAt: Date;
+}
+
+export const ResponseSchema = SchemaFactory.createForClass(ResponseSchemaClass);
+
+ResponseSchema.index({ formId: 1 });
+ResponseSchema.index({ formId: 1, submittedAt: -1 });
+ResponseSchema.index({ organizationId: 1 });

--- a/formix-backend/src/modules/responses/responses.module.ts
+++ b/formix-backend/src/modules/responses/responses.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ResponseSchemaClass, ResponseSchema } from './infra/schemas/response.schema';
+import { ResponseEmailSchemaClass, ResponseEmailSchema } from './infra/schemas/response-email.schema';
+import { MongoResponseRepository } from './infra/repositories/mongo-response.repository';
+import { MongoResponseEmailRepository } from './infra/repositories/mongo-response-email.repository';
+import { RESPONSE_REPOSITORY } from './domain/repositories/response.repository';
+import { RESPONSE_EMAIL_REPOSITORY } from './domain/repositories/response-email.repository';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ResponseSchemaClass.name, schema: ResponseSchema },
+      { name: ResponseEmailSchemaClass.name, schema: ResponseEmailSchema },
+    ]),
+  ],
+  providers: [
+    { provide: RESPONSE_REPOSITORY, useClass: MongoResponseRepository },
+    { provide: RESPONSE_EMAIL_REPOSITORY, useClass: MongoResponseEmailRepository },
+  ],
+  exports: [RESPONSE_REPOSITORY, RESPONSE_EMAIL_REPOSITORY],
+})
+export class ResponsesModule {}

--- a/formix-backend/src/modules/responses/responses.module.ts
+++ b/formix-backend/src/modules/responses/responses.module.ts
@@ -6,6 +6,10 @@ import { MongoResponseRepository } from './infra/repositories/mongo-response.rep
 import { MongoResponseEmailRepository } from './infra/repositories/mongo-response-email.repository';
 import { RESPONSE_REPOSITORY } from './domain/repositories/response.repository';
 import { RESPONSE_EMAIL_REPOSITORY } from './domain/repositories/response-email.repository';
+import { SubmitResponseUseCase } from './domain/usecases/submit-response.usecase';
+import { ListResponsesUseCase } from './domain/usecases/list-responses.usecase';
+import { ResponsesController } from './infra/controllers/responses.controller';
+import { FormsModule } from '@modules/forms/forms.module';
 
 @Module({
   imports: [
@@ -13,10 +17,14 @@ import { RESPONSE_EMAIL_REPOSITORY } from './domain/repositories/response-email.
       { name: ResponseSchemaClass.name, schema: ResponseSchema },
       { name: ResponseEmailSchemaClass.name, schema: ResponseEmailSchema },
     ]),
+    FormsModule,
   ],
+  controllers: [ResponsesController],
   providers: [
     { provide: RESPONSE_REPOSITORY, useClass: MongoResponseRepository },
     { provide: RESPONSE_EMAIL_REPOSITORY, useClass: MongoResponseEmailRepository },
+    SubmitResponseUseCase,
+    ListResponsesUseCase,
   ],
   exports: [RESPONSE_REPOSITORY, RESPONSE_EMAIL_REPOSITORY],
 })

--- a/formix-frontend/src/app/(app)/forms/[id]/responses/page.tsx
+++ b/formix-frontend/src/app/(app)/forms/[id]/responses/page.tsx
@@ -1,15 +1,165 @@
-import { PageContainer } from '@/components/Layout';
+'use client';
 
-interface FormResponsesPageProps {
-  params: Promise<{ id: string }>;
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { PageContainer } from '@/components/Layout';
+import { Button } from '@/components/ui/button';
+import { getForm } from '@/services/forms/forms.service';
+import { listResponses } from '@/services/responses/responses.service';
+import type { FormDetail } from '@/services/forms/forms.types';
+import type { ListResponsesOutput } from '@/services/responses/responses.types';
+
+const DEFAULT_LIMIT = 20;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
-export default async function FormResponsesPage({ params }: FormResponsesPageProps) {
-  const { id } = await params;
+function getAnswerValue(answers: { questionId: string; value: unknown }[], questionId: string): string {
+  const answer = answers.find((a) => a.questionId === questionId);
+  if (answer === undefined || answer.value === null || answer.value === undefined) return '—';
+  if (Array.isArray(answer.value)) return answer.value.join(', ');
+  return String(answer.value);
+}
+
+export default function FormResponsesPage() {
+  const { id } = useParams<{ id: string }>();
+
+  const [form, setForm] = useState<FormDetail | null>(null);
+  const [data, setData] = useState<ListResponsesOutput | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(
+    async (newOffset: number) => {
+      setLoading(true);
+      try {
+        const [formData, responsesData] = await Promise.all([
+          form ? Promise.resolve(form) : getForm(id),
+          listResponses(id, newOffset, DEFAULT_LIMIT),
+        ]);
+        setForm(formData);
+        setData(responsesData);
+        setOffset(newOffset);
+      } catch {
+        setError('Erro ao carregar respostas.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [id],
+  );
+
+  useEffect(() => {
+    load(0);
+  }, [load]);
+
+  const totalPages = data ? Math.ceil(data.total / DEFAULT_LIMIT) : 0;
+  const currentPage = Math.floor(offset / DEFAULT_LIMIT) + 1;
+
   return (
     <PageContainer>
-      <h1>Respostas</h1>
-      <p>ID: {id} — Conteúdo em breve (US-042).</p>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">{form?.title ?? 'Respostas'}</h1>
+            {data && (
+              <p className="text-sm text-muted-foreground">
+                {data.total} {data.total === 1 ? 'resposta' : 'respostas'} no total
+              </p>
+            )}
+          </div>
+          <Button variant="outline" asChild>
+            <Link href="/forms">Voltar</Link>
+          </Button>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {loading ? (
+          <p className="text-muted-foreground">Carregando...</p>
+        ) : data?.responses.length === 0 ? (
+          <div className="rounded-lg border p-8 text-center">
+            <p className="text-muted-foreground">Nenhuma resposta recebida ainda.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="whitespace-nowrap px-4 py-3 text-left font-medium">Data</th>
+                  {form?.questions
+                    .slice()
+                    .sort((a, b) => a.order - b.order)
+                    .map((q) => (
+                      <th
+                        key={q.id}
+                        className="whitespace-nowrap px-4 py-3 text-left font-medium max-w-[200px]"
+                      >
+                        {q.label}
+                      </th>
+                    ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {data?.responses.map((row) => (
+                  <tr key={row.id} className="hover:bg-muted/30">
+                    <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
+                      {formatDate(row.submittedAt)}
+                    </td>
+                    {form?.questions
+                      .slice()
+                      .sort((a, b) => a.order - b.order)
+                      .map((q) => (
+                        <td
+                          key={q.id}
+                          className="px-4 py-3 max-w-[200px] truncate"
+                          title={getAnswerValue(row.answers, q.id)}
+                        >
+                          {getAnswerValue(row.answers, q.id)}
+                        </td>
+                      ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              Página {currentPage} de {totalPages}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset === 0}
+                onClick={() => load(Math.max(0, offset - DEFAULT_LIMIT))}
+              >
+                Anterior
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset + DEFAULT_LIMIT >= (data?.total ?? 0)}
+                onClick={() => load(offset + DEFAULT_LIMIT)}
+              >
+                Próxima
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
     </PageContainer>
   );
 }

--- a/formix-frontend/src/app/(public)/f/[publicToken]/page.tsx
+++ b/formix-frontend/src/app/(public)/f/[publicToken]/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { getPublicForm, submitResponse } from '@/services/responses/responses.service';
+import type { PublicForm, Answer } from '@/services/responses/responses.types';
+import { QuestionRenderer } from '@/modules/QuestionRenderer/QuestionRenderer';
+import { EmailInput } from '@/components/inputs';
+import { Button } from '@/components/ui/button';
+
+type PageState = 'loading' | 'error' | 'form' | 'submitting' | 'success';
+
+export default function PublicFormPage() {
+  const params = useParams<{ publicToken: string }>();
+  const { publicToken } = params;
+
+  const [state, setState] = useState<PageState>('loading');
+  const [form, setForm] = useState<PublicForm | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [answers, setAnswers] = useState<Record<string, unknown>>({});
+  const [answerErrors, setAnswerErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState('');
+
+  useEffect(() => {
+    getPublicForm(publicToken)
+      .then((data) => {
+        if (data.status !== 'active') {
+          setErrorMessage(
+            data.status === 'expired'
+              ? 'Este formulário expirou.'
+              : 'Este formulário não está mais aceitando respostas.',
+          );
+          setState('error');
+        } else {
+          setForm(data);
+          setState('form');
+        }
+      })
+      .catch(() => {
+        setErrorMessage('Formulário não encontrado.');
+        setState('error');
+      });
+  }, [publicToken]);
+
+  function handleAnswerChange(questionId: string, value: unknown) {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+    setAnswerErrors((prev) => ({ ...prev, [questionId]: '' }));
+  }
+
+  function validate(): boolean {
+    let valid = true;
+    const newErrors: Record<string, string> = {};
+
+    if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('Email válido é obrigatório');
+      valid = false;
+    } else {
+      setEmailError('');
+    }
+
+    if (!form) return false;
+    for (const question of form.questions) {
+      const value = answers[question.id];
+      if (question.required) {
+        if (
+          value === undefined ||
+          value === null ||
+          value === '' ||
+          (Array.isArray(value) && value.length === 0)
+        ) {
+          newErrors[question.id] = 'Este campo é obrigatório';
+          valid = false;
+        }
+      }
+    }
+
+    setAnswerErrors(newErrors);
+    return valid;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setState('submitting');
+    setSubmitError('');
+
+    const answersArray: Answer[] = Object.entries(answers).map(([questionId, value]) => ({
+      questionId,
+      value,
+    }));
+
+    try {
+      await submitResponse(publicToken, { email, answers: answersArray });
+      setState('success');
+    } catch (err: unknown) {
+      setState('form');
+      const status = (err as { response?: { status?: number; data?: { message?: string } } })
+        ?.response?.status;
+      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data
+        ?.message;
+      if (status === 409) {
+        setSubmitError('Você já respondeu este formulário.');
+      } else if (status === 403) {
+        setSubmitError('Seu domínio de email não é permitido neste formulário.');
+      } else if (status === 400) {
+        setSubmitError(typeof msg === 'string' ? msg : 'Resposta inválida. Verifique os campos.');
+      } else {
+        setSubmitError('Erro ao enviar resposta. Tente novamente.');
+      }
+    }
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Carregando formulário...</p>
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className="max-w-md w-full text-center space-y-4">
+          <h1 className="text-2xl font-bold">Formulário indisponível</h1>
+          <p className="text-muted-foreground">{errorMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'success') {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <div className="max-w-md w-full text-center space-y-4">
+          <div className="text-5xl">✓</div>
+          <h1 className="text-2xl font-bold">Resposta enviada com sucesso!</h1>
+          <p className="text-muted-foreground">Obrigado por responder este formulário.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background py-8 px-4">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">{form!.title}</h1>
+          {form!.description && (
+            <p className="text-muted-foreground">{form!.description}</p>
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <EmailInput
+            label="Seu email"
+            value={email}
+            onChange={setEmail}
+            required
+            error={emailError}
+            placeholder="seu@email.com"
+          />
+
+          {form!.questions.map((question) => (
+            <QuestionRenderer
+              key={question.id}
+              question={question}
+              value={answers[question.id]}
+              onChange={(v) => handleAnswerChange(question.id, v)}
+              error={answerErrors[question.id]}
+            />
+          ))}
+
+          {submitError && (
+            <p className="text-sm text-destructive" role="alert">{submitError}</p>
+          )}
+
+          <Button type="submit" disabled={state === 'submitting'} className="w-full">
+            {state === 'submitting' ? 'Enviando...' : 'Enviar resposta'}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/QuestionRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/QuestionRenderer.tsx
@@ -1,0 +1,50 @@
+import type { PublicFormQuestion } from '@/services/responses/responses.types';
+import { TextRenderer } from './renderers/TextRenderer';
+import { TextareaRenderer } from './renderers/TextareaRenderer';
+import { CheckboxRenderer } from './renderers/CheckboxRenderer';
+import { RadioRenderer } from './renderers/RadioRenderer';
+import { ToggleRenderer } from './renderers/ToggleRenderer';
+import { DropdownRenderer } from './renderers/DropdownRenderer';
+import { NumberRenderer } from './renderers/NumberRenderer';
+import { DateRenderer } from './renderers/DateRenderer';
+import { RatingRenderer } from './renderers/RatingRenderer';
+import { FileRenderer } from './renderers/FileRenderer';
+import { EmailRenderer } from './renderers/EmailRenderer';
+
+export interface RendererProps {
+  question: PublicFormQuestion;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  error?: string;
+}
+
+export function QuestionRenderer({ question, value, onChange, error }: RendererProps) {
+  const props = { question, value, onChange, error };
+
+  switch (question.type) {
+    case 'text':
+      return <TextRenderer {...props} />;
+    case 'textarea':
+      return <TextareaRenderer {...props} />;
+    case 'checkbox':
+      return <CheckboxRenderer {...props} />;
+    case 'radio':
+      return <RadioRenderer {...props} />;
+    case 'toggle':
+      return <ToggleRenderer {...props} />;
+    case 'dropdown':
+      return <DropdownRenderer {...props} />;
+    case 'number':
+      return <NumberRenderer {...props} />;
+    case 'date':
+      return <DateRenderer {...props} />;
+    case 'rating':
+      return <RatingRenderer {...props} />;
+    case 'file':
+      return <FileRenderer {...props} />;
+    case 'email':
+      return <EmailRenderer {...props} />;
+    default:
+      return null;
+  }
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/CheckboxRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/CheckboxRenderer.tsx
@@ -1,0 +1,16 @@
+import { Checkbox } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function CheckboxRenderer({ question, value, onChange, error }: RendererProps) {
+  const options = (question.options ?? []).map(o => ({ label: o, value: o }));
+  return (
+    <Checkbox
+      label={question.label}
+      value={(value as string[]) ?? []}
+      onChange={onChange}
+      options={options}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/DateRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/DateRenderer.tsx
@@ -1,0 +1,14 @@
+import { DatePicker } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function DateRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <DatePicker
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/DropdownRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/DropdownRenderer.tsx
@@ -1,0 +1,17 @@
+import { Dropdown } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function DropdownRenderer({ question, value, onChange, error }: RendererProps) {
+  const options = (question.options ?? []).map(o => ({ label: o, value: o }));
+  return (
+    <Dropdown
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      options={options}
+      required={question.required}
+      error={error}
+      placeholder="Selecione uma opção"
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/EmailRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/EmailRenderer.tsx
@@ -1,0 +1,14 @@
+import { EmailInput } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function EmailRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <EmailInput
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/FileRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/FileRenderer.tsx
@@ -1,0 +1,14 @@
+import { FileUpload } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function FileRenderer({ question, onChange, error }: RendererProps) {
+  return (
+    <FileUpload
+      label={question.label}
+      value={null}
+      onChange={() => onChange(null)}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/NumberRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/NumberRenderer.tsx
@@ -1,0 +1,16 @@
+import { NumberInput } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function NumberRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <NumberInput
+      label={question.label}
+      value={value !== undefined && value !== null ? Number(value) : null}
+      onChange={onChange}
+      required={question.required}
+      min={question.validation?.min}
+      max={question.validation?.max}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/RadioRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/RadioRenderer.tsx
@@ -1,0 +1,16 @@
+import { RadioGroup } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function RadioRenderer({ question, value, onChange, error }: RendererProps) {
+  const options = (question.options ?? []).map(o => ({ label: o, value: o }));
+  return (
+    <RadioGroup
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      options={options}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/RatingRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/RatingRenderer.tsx
@@ -1,0 +1,15 @@
+import { RatingInput } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function RatingRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <RatingInput
+      label={question.label}
+      value={value !== undefined && value !== null ? Number(value) : null}
+      onChange={onChange}
+      required={question.required}
+      max={question.validation?.max ?? 5}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/TextRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/TextRenderer.tsx
@@ -1,0 +1,14 @@
+import { TextInput } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function TextRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <TextInput
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/TextareaRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/TextareaRenderer.tsx
@@ -1,0 +1,14 @@
+import { TextArea } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function TextareaRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <TextArea
+      label={question.label}
+      value={(value as string) ?? ''}
+      onChange={onChange}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/modules/QuestionRenderer/renderers/ToggleRenderer.tsx
+++ b/formix-frontend/src/modules/QuestionRenderer/renderers/ToggleRenderer.tsx
@@ -1,0 +1,14 @@
+import { Toggle } from '@/components/inputs';
+import type { RendererProps } from '../QuestionRenderer';
+
+export function ToggleRenderer({ question, value, onChange, error }: RendererProps) {
+  return (
+    <Toggle
+      label={question.label}
+      value={(value as boolean) ?? false}
+      onChange={onChange}
+      required={question.required}
+      error={error}
+    />
+  );
+}

--- a/formix-frontend/src/services/responses/responses.service.ts
+++ b/formix-frontend/src/services/responses/responses.service.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import { httpClient } from '@/services/http-client';
+import type {
+  PublicForm,
+  SubmitResponseInput,
+  ListResponsesOutput,
+} from './responses.types';
+
+const publicClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+});
+
+export async function getPublicForm(publicToken: string): Promise<PublicForm> {
+  const response = await publicClient.get<PublicForm>(`/forms/public/${publicToken}`);
+  return response.data;
+}
+
+export async function submitResponse(
+  publicToken: string,
+  data: SubmitResponseInput,
+): Promise<{ submitted: boolean }> {
+  const response = await publicClient.post<{ submitted: boolean }>(
+    `/responses/${publicToken}`,
+    data,
+  );
+  return response.data;
+}
+
+export async function listResponses(
+  formId: string,
+  offset = 0,
+  limit = 20,
+): Promise<ListResponsesOutput> {
+  const response = await httpClient.get<ListResponsesOutput>(
+    `/forms/${formId}/responses`,
+    { params: { offset, limit } },
+  );
+  return response.data;
+}

--- a/formix-frontend/src/services/responses/responses.types.ts
+++ b/formix-frontend/src/services/responses/responses.types.ts
@@ -1,0 +1,43 @@
+import type { QuestionType } from '@/services/forms/forms.types';
+
+export interface PublicFormQuestion {
+  id: string;
+  type: QuestionType;
+  label: string;
+  description?: string;
+  required: boolean;
+  order: number;
+  options?: string[];
+  validation?: { min?: number; max?: number; pattern?: string };
+}
+
+export interface PublicForm {
+  id: string;
+  title: string;
+  description?: string;
+  status: string;
+  questions: PublicFormQuestion[];
+}
+
+export interface Answer {
+  questionId: string;
+  value: unknown;
+}
+
+export interface SubmitResponseInput {
+  email: string;
+  answers: Answer[];
+}
+
+export interface ResponseRow {
+  id: string;
+  answers: Answer[];
+  submittedAt: string;
+}
+
+export interface ListResponsesOutput {
+  responses: ResponseRow[];
+  total: number;
+  offset: number;
+  limit: number;
+}


### PR DESCRIPTION
## Descrição

Implementa a Fase 7 completa do Formix: coleta anônima de respostas via link público e visualização de respostas no painel. O fluxo cobre desde os schemas MongoDB até as páginas de frontend. O princípio de anonimato é respeitado: respostas são armazenadas sem qualquer identificador do respondente; o hash do email fica em coleção separada sem FK.

---

## Closes

Closes #44
Closes #45
Closes #46
Closes #47
Closes #48

---

## Commits

### `4dbdcd1` — feat(responses): add response and response-email domain aggregates and repository interfaces

Cria a camada de domínio do módulo `responses`. `ResponseAggregate` representa uma resposta anônima (`formId`, `organizationId`, `answers[]`, `submittedAt`) — sem campo de email. `ResponseEmailAggregate` representa o registro de duplicidade (`formId`, `emailHash`, `respondedAt`) — sem FK para responses. Ambos possuem value objects de ID tipados (`ResponseId`, `ResponseEmailId`). As interfaces `IResponseRepository` e `IResponseEmailRepository` definem os contratos de persistência.

---

### `c786c96` — feat(responses): add mongoose schemas and mongo repository implementations

Cria os schemas Mongoose (`response.schema.ts`, `response-email.schema.ts`) com índices compostos para consultas eficientes, e as implementações de repositório (`MongoResponseRepository`, `MongoResponseEmailRepository`) com testes de integração usando `mongodb-memory-server`. O `responses.module.ts` registra todos os providers e schemas.

---

### `894da4b` — feat(responses): implement submit-response and list-responses use cases with controller

Implementa `SubmitResponseUseCase` (US-039): valida form ativo, verifica duplicidade por hash SHA-256 do email, confere domínio permitido, salva resposta e email em operações independentes sem vínculo entre si. Implementa `ListResponsesUseCase` (US-041): retorna respostas paginadas filtrando por `organizationId`. `ResponsesController` expõe `POST /responses/:publicToken` (público) e `GET /forms/:id/responses` (autenticado) com Swagger completo. Adiciona cascata de deleção de respostas no `DeleteFormUseCase`.

---

### `eaa4551` — feat(responses): add get-public-form use case and endpoint

Cria `GetPublicFormUseCase` no módulo `forms`: busca form por `publicToken` e retorna dados públicos com perguntas ordenadas. Expõe `GET /forms/public/:publicToken` como rota pública no `ResponsesController`. Exporta o use case do `FormsModule` para uso no `ResponsesModule`. Corrige o teste de integração do controller para incluir `GetPublicFormUseCase` nos providers.

---

### `c409383` — feat(frontend): add responses service and types

Adiciona `responses.types.ts` com os tipos `PublicForm`, `PublicFormQuestion`, `Answer`, `SubmitResponseInput`, `ResponseRow` e `ListResponsesOutput`. O `responses.service.ts` expõe três funções: `getPublicForm` (GET sem auth via cliente axios direto), `submitResponse` (POST sem auth) e `listResponses` (GET autenticado via `httpClient`).

---

### `260b052` — feat(frontend): add QuestionRenderer with all 11 question type renderers

Cria o componente `QuestionRenderer` que despacha por `question.type` para um dos 11 renderers específicos: `TextRenderer`, `TextareaRenderer`, `CheckboxRenderer`, `RadioRenderer`, `ToggleRenderer`, `DropdownRenderer`, `NumberRenderer`, `DateRenderer`, `RatingRenderer`, `FileRenderer` e `EmailRenderer`. Todos seguem a interface `RendererProps` uniforme e reutilizam os componentes de input existentes em `@/components/inputs`.

---

### `ae9edc3` — feat(frontend): add public form page at /f/:publicToken

Implementa US-040: página pública em `/f/:publicToken` sem AppShell. Gerencia os estados `loading → error → form → submitting → success`. Carrega o form pelo token, exibe título/descrição, campo de email obrigatório no topo e todas as perguntas via `QuestionRenderer`. Validação client-side de campos `required`. Tratamento de erros por status HTTP: 409 (duplicidade), 403 (domínio inválido), 400 (dados inválidos). Tela de confirmação após envio bem-sucedido.

---

### `dc5a1b1` — feat(frontend): implement responses table page at /forms/:id/responses

Implementa US-042: página autenticada `/forms/:id/responses` com tabela de scroll horizontal. Carrega o form (para usar os labels das perguntas como cabeçalhos) e as respostas em paralelo. Tabela exibe data de submissão e uma coluna por pergunta — nenhum dado de respondente. Paginação com previous/next e indicador de página/total. Estados de loading, vazio e erro.

---

## Checklist

- [x] Todos os testes passando (361 testes, 62 suites)
- [x] `npm run typecheck` passa no backend e frontend
- [x] `npm run build` passa no frontend
- [x] Sem arquivos sensíveis (.env, secrets)
- [x] Import rules do DDD respeitadas (domain não importa infra)
- [x] Swagger documentado em todos os endpoints novos
- [x] `progress.md` atualizado com todas as USs da fase
- [x] Multi-tenancy: queries filtram por organizationId
- [x] Anonimato: respostas sem email, response_emails sem FK para responses