### PR TITLE
fix(project): backend fixes, dark mode, expire-form and search/sort in responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 .pnp/
 .pnp.js
 
+.playwright-mcp/
+
 # Build
 dist/
 build/

--- a/formix-backend/src/main.ts
+++ b/formix-backend/src/main.ts
@@ -1,9 +1,22 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Formix API')
+    .setDescription('API documentation for Formix')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, document);
+
   const port = process.env.PORT || 3001;
   await app.listen(port);
   console.log(`Application is running on port ${port}`);

--- a/formix-backend/src/modules/auth/domain/usecases/login.usecase.ts
+++ b/formix-backend/src/modules/auth/domain/usecases/login.usecase.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import { Inject, Injectable } from '@nestjs/common';
 import { IUserRepository, USER_REPOSITORY } from '@modules/users/domain/repositories/user.repository';
 import { IOrganizationRepository, ORGANIZATION_REPOSITORY } from '@modules/organizations/domain/repositories/organization.repository';
@@ -57,6 +56,8 @@ export class LoginUseCase {
 
     const accessToken = this.jwtSign({
       sub: user.id.getValue(),
+      name: user.name,
+      email: user.email.getValue(),
       organizationId: org.id.getValue(),
       role,
     });

--- a/formix-backend/src/modules/auth/domain/usecases/refresh-token.usecase.ts
+++ b/formix-backend/src/modules/auth/domain/usecases/refresh-token.usecase.ts
@@ -69,6 +69,8 @@ export class RefreshTokenUseCase {
 
     const accessToken = this.jwtSign({
       sub: user.id.getValue(),
+      name: user.name,
+      email: user.email.getValue(),
       organizationId: org.id.getValue(),
       role,
     });

--- a/formix-backend/src/modules/auth/infra/controllers/auth.controller.test.ts
+++ b/formix-backend/src/modules/auth/infra/controllers/auth.controller.test.ts
@@ -172,7 +172,7 @@ describe('AuthController (integration)', () => {
       expect(response.status).toBe(401);
     });
 
-    it('should return 400 when email not confirmed', async () => {
+    it('should return 403 when email not confirmed', async () => {
       // Signup creates unconfirmed user
       await request(app.getHttpServer()).post('/auth/signup').send({
         name: 'Unconfirmed',
@@ -186,7 +186,7 @@ describe('AuthController (integration)', () => {
         password: 'SecurePass1',
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(403);
       expect(response.body.message).toBe('Email not confirmed');
     });
   });

--- a/formix-backend/src/modules/auth/infra/controllers/auth.controller.ts
+++ b/formix-backend/src/modules/auth/infra/controllers/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   ConflictException,
   Controller,
+  ForbiddenException,
   HttpCode,
   Post,
   UnauthorizedException,
@@ -103,14 +104,17 @@ export class AuthController {
   @ApiOperation({ summary: 'Login with email and password' })
   @ApiBody({ type: LoginDto })
   @ApiResponse({ status: 200, description: 'Login successful', type: LoginResponseDto })
-  @ApiResponse({ status: 400, description: 'Invalid credentials or email not confirmed' })
-  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 401, description: 'Invalid credentials' })
+  @ApiResponse({ status: 403, description: 'Email not confirmed' })
   async login(@Body() dto: LoginDto): Promise<LoginResponseDto> {
     const output = await this.loginUseCase.execute(dto);
 
     if (output.isFailure) {
       if (output.errorMessage === 'Invalid credentials') {
         throw new UnauthorizedException(output.errorMessage);
+      }
+      if (output.errorMessage === 'Email not confirmed') {
+        throw new ForbiddenException(output.errorMessage);
       }
       throw new BadRequestException(output.errorMessage);
     }

--- a/formix-backend/src/modules/forms/domain/aggregate/form.aggregate.ts
+++ b/formix-backend/src/modules/forms/domain/aggregate/form.aggregate.ts
@@ -91,6 +91,15 @@ export class FormAggregate {
     this.props.updatedAt = new Date();
   }
 
+  unpublish(): void {
+    if (!this.props.status.isActive()) {
+      throw new Error('Form can only be unpublished from active status');
+    }
+    this.props.publicToken = undefined;
+    this.props.status = FormStatus.draft();
+    this.props.updatedAt = new Date();
+  }
+
   isExpired(): boolean {
     if (!this.props.settings.expiresAt) return false;
     return new Date() > this.props.settings.expiresAt;

--- a/formix-backend/src/modules/forms/forms.module.ts
+++ b/formix-backend/src/modules/forms/forms.module.ts
@@ -4,6 +4,8 @@ import { FormSchemaClass, FormSchema } from './infra/schemas/form.schema';
 import { QuestionSchemaClass, QuestionSchema } from './infra/schemas/question.schema';
 import { MongoFormRepository } from './infra/repositories/mongo-form.repository';
 import { MongoQuestionRepository } from './infra/repositories/mongo-question.repository';
+import { FormMapper } from './infra/repositories/form.mapper';
+import { QuestionMapper } from './infra/repositories/question.mapper';
 import { FORM_REPOSITORY } from './domain/repositories/form.repository';
 import { QUESTION_REPOSITORY } from './domain/repositories/question.repository';
 import { CreateFormUseCase } from './domain/usecases/create-form.usecase';
@@ -29,6 +31,8 @@ import { FormsController } from './infra/controllers/forms.controller';
   ],
   controllers: [FormsController],
   providers: [
+    FormMapper,
+    QuestionMapper,
     { provide: FORM_REPOSITORY, useClass: MongoFormRepository },
     { provide: QUESTION_REPOSITORY, useClass: MongoQuestionRepository },
     CreateFormUseCase,

--- a/formix-backend/src/modules/forms/infra/repositories/form.mapper.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/form.mapper.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { BidirectionalMapper } from '@shared/bidirectional-mapper';
+import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
+import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
+import { FormStatus } from '@modules/forms/domain/aggregate/value-objects/form-status.vo';
+import { PublicToken } from '@modules/forms/domain/aggregate/value-objects/public-token.vo';
+
+export interface FormSchemaDto {
+  _id: string;
+  organizationId: string;
+  createdBy: string;
+  title: string;
+  description?: string;
+  publicToken?: string;
+  settings: {
+    expiresAt?: Date;
+    maxResponses?: number;
+    allowMultipleResponses: boolean;
+    allowedEmailDomains: string[];
+  };
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+@Injectable()
+export class FormMapper implements BidirectionalMapper<FormAggregate, FormSchemaDto> {
+  toRight(form: FormAggregate): FormSchemaDto {
+    return {
+      _id: form.id.getValue(),
+      organizationId: form.organizationId,
+      createdBy: form.createdBy,
+      title: form.title,
+      description: form.description,
+      publicToken: form.publicToken?.getValue(),
+      settings: form.settings,
+      status: form.status.getValue(),
+      createdAt: form.createdAt,
+      updatedAt: form.updatedAt,
+    };
+  }
+
+  toLeft(dto: FormSchemaDto): FormAggregate {
+    return FormAggregate.reconstitute({
+      id: FormId.from(dto._id),
+      organizationId: dto.organizationId,
+      createdBy: dto.createdBy,
+      title: dto.title,
+      description: dto.description,
+      publicToken: dto.publicToken ? PublicToken.from(dto.publicToken) : undefined,
+      settings: dto.settings,
+      status: FormStatus.from(dto.status),
+      createdAt: dto.createdAt,
+      updatedAt: dto.updatedAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/forms/infra/repositories/mongo-form.repository.test.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/mongo-form.repository.test.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { MongoFormRepository } from './mongo-form.repository';
+import { FormMapper } from './form.mapper';
 import { FormSchemaClass, FormSchema } from '../schemas/form.schema';
 import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
 import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
@@ -26,7 +27,7 @@ describe('MongoFormRepository (integration)', () => {
         MongooseModule.forRoot(mongod.getUri()),
         MongooseModule.forFeature([{ name: FormSchemaClass.name, schema: FormSchema }]),
       ],
-      providers: [MongoFormRepository],
+      providers: [FormMapper, MongoFormRepository],
     }).compile();
 
     repo = module.get(MongoFormRepository);

--- a/formix-backend/src/modules/forms/infra/repositories/mongo-form.repository.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/mongo-form.repository.ts
@@ -4,75 +4,52 @@ import { Model } from 'mongoose';
 import { IFormRepository } from '@modules/forms/domain/repositories/form.repository';
 import { FormAggregate } from '@modules/forms/domain/aggregate/form.aggregate';
 import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
-import { FormStatus } from '@modules/forms/domain/aggregate/value-objects/form-status.vo';
-import { PublicToken } from '@modules/forms/domain/aggregate/value-objects/public-token.vo';
 import { Output } from '@shared/output';
 import { FormDocument, FormSchemaClass } from '../schemas/form.schema';
+import { FormMapper, FormSchemaDto } from './form.mapper';
 
 @Injectable()
 export class MongoFormRepository implements IFormRepository {
   constructor(
     @InjectModel(FormSchemaClass.name)
     private readonly formModel: Model<FormDocument>,
+    private readonly formMapper: FormMapper,
   ) {}
 
   async save(form: FormAggregate): Promise<void> {
-    await this.formModel.findOneAndUpdate(
-      { _id: form.id.getValue() },
-      {
-        $set: {
-          organizationId: form.organizationId,
-          createdBy: form.createdBy,
-          title: form.title,
-          description: form.description,
-          publicToken: form.publicToken?.getValue(),
-          settings: form.settings,
-          status: form.status.getValue(),
-        },
-        $setOnInsert: {
-          _id: form.id.getValue(),
-          createdAt: form.createdAt,
-        },
-      },
-      { upsert: true },
-    );
+    const dto = this.formMapper.toRight(form);
+
+    const alreadyExists = await this.formModel.exists({ _id: dto._id });
+
+    if (!alreadyExists) {
+      await this.formModel.create(dto);
+      return;
+    }
+
+    dto.updatedAt = new Date();
+    await this.formModel.replaceOne({ _id: dto._id }, dto);
   }
 
   async findById(id: FormId): Promise<Output<FormAggregate>> {
-    const doc = await this.formModel.findOne({ _id: id.getValue() }).exec();
+    const doc = await this.formModel.findOne({ _id: id.getValue() }).lean().exec();
     if (!doc) return Output.fail('Form not found');
-    return Output.ok(this.toEntity(doc));
+    return Output.ok(this.formMapper.toLeft(doc as unknown as FormSchemaDto));
   }
 
   async findByOrganizationId(organizationId: string, status?: string): Promise<FormAggregate[]> {
     const filter: Record<string, unknown> = { organizationId };
     if (status) filter.status = status;
-    const docs = await this.formModel.find(filter).exec();
-    return docs.map(doc => this.toEntity(doc));
+    const docs = await this.formModel.find(filter).lean().exec();
+    return docs.map((doc) => this.formMapper.toLeft(doc as unknown as FormSchemaDto));
   }
 
   async findByPublicToken(publicToken: string): Promise<Output<FormAggregate>> {
-    const doc = await this.formModel.findOne({ publicToken }).exec();
+    const doc = await this.formModel.findOne({ publicToken }).lean().exec();
     if (!doc) return Output.fail('Form not found');
-    return Output.ok(this.toEntity(doc));
+    return Output.ok(this.formMapper.toLeft(doc as unknown as FormSchemaDto));
   }
 
   async delete(id: FormId): Promise<void> {
     await this.formModel.deleteOne({ _id: id.getValue() }).exec();
-  }
-
-  private toEntity(doc: FormDocument): FormAggregate {
-    return FormAggregate.reconstitute({
-      id: FormId.from(doc._id as string),
-      organizationId: doc.organizationId,
-      createdBy: doc.createdBy,
-      title: doc.title,
-      description: doc.description,
-      publicToken: doc.publicToken ? PublicToken.from(doc.publicToken) : undefined,
-      settings: doc.settings,
-      status: FormStatus.from(doc.status),
-      createdAt: doc.createdAt,
-      updatedAt: doc.updatedAt,
-    });
   }
 }

--- a/formix-backend/src/modules/forms/infra/repositories/mongo-question.repository.test.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/mongo-question.repository.test.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { MongoQuestionRepository } from './mongo-question.repository';
+import { QuestionMapper } from './question.mapper';
 import { QuestionSchemaClass, QuestionSchema } from '../schemas/question.schema';
 import { QuestionEntity } from '@modules/forms/domain/aggregate/question.entity';
 import { QuestionId } from '@modules/forms/domain/aggregate/value-objects/question-id.vo';
@@ -28,7 +29,7 @@ describe('MongoQuestionRepository (integration)', () => {
         MongooseModule.forRoot(mongod.getUri()),
         MongooseModule.forFeature([{ name: QuestionSchemaClass.name, schema: QuestionSchema }]),
       ],
-      providers: [MongoQuestionRepository],
+      providers: [QuestionMapper, MongoQuestionRepository],
     }).compile();
 
     repo = module.get(MongoQuestionRepository);

--- a/formix-backend/src/modules/forms/infra/repositories/mongo-question.repository.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/mongo-question.repository.ts
@@ -4,55 +4,45 @@ import { Model } from 'mongoose';
 import { IQuestionRepository } from '@modules/forms/domain/repositories/question.repository';
 import { QuestionEntity } from '@modules/forms/domain/aggregate/question.entity';
 import { QuestionId } from '@modules/forms/domain/aggregate/value-objects/question-id.vo';
-import { QuestionType } from '@modules/forms/domain/aggregate/value-objects/question-type.vo';
 import { Output } from '@shared/output';
 import { QuestionDocument, QuestionSchemaClass } from '../schemas/question.schema';
+import { QuestionMapper, QuestionSchemaDto } from './question.mapper';
 
 @Injectable()
 export class MongoQuestionRepository implements IQuestionRepository {
   constructor(
     @InjectModel(QuestionSchemaClass.name)
     private readonly questionModel: Model<QuestionDocument>,
+    private readonly questionMapper: QuestionMapper,
   ) {}
 
   async save(question: QuestionEntity): Promise<void> {
-    await this.questionModel.findOneAndUpdate(
-      { _id: question.id.getValue() },
-      {
-        $set: {
-          formId: question.formId,
-          organizationId: question.organizationId,
-          type: question.type.getValue(),
-          label: question.label,
-          description: question.description,
-          required: question.required,
-          order: question.order,
-          options: question.options,
-          validation: question.validation,
-        },
-        $setOnInsert: {
-          _id: question.id.getValue(),
-          createdAt: question.createdAt,
-        },
-      },
-      { upsert: true },
-    );
+    const dto = this.questionMapper.toRight(question);
+
+    const alreadyExists = await this.questionModel.exists({ _id: dto._id });
+
+    if (!alreadyExists) {
+      await this.questionModel.create(dto);
+      return;
+    }
+
+    await this.questionModel.replaceOne({ _id: dto._id }, dto);
   }
 
   async findById(id: QuestionId): Promise<Output<QuestionEntity>> {
-    const doc = await this.questionModel.findOne({ _id: id.getValue() }).exec();
+    const doc = await this.questionModel.findOne({ _id: id.getValue() }).lean().exec();
     if (!doc) return Output.fail('Question not found');
-    return Output.ok(this.toEntity(doc));
+    return Output.ok(this.questionMapper.toLeft(doc as unknown as QuestionSchemaDto));
   }
 
   async findByFormId(formId: string): Promise<QuestionEntity[]> {
-    const docs = await this.questionModel.find({ formId }).exec();
-    return docs.map(doc => this.toEntity(doc));
+    const docs = await this.questionModel.find({ formId }).lean().exec();
+    return docs.map((doc) => this.questionMapper.toLeft(doc as unknown as QuestionSchemaDto));
   }
 
   async findByFormIdOrdered(formId: string): Promise<QuestionEntity[]> {
-    const docs = await this.questionModel.find({ formId }).sort({ order: 1 }).exec();
-    return docs.map(doc => this.toEntity(doc));
+    const docs = await this.questionModel.find({ formId }).sort({ order: 1 }).lean().exec();
+    return docs.map((doc) => this.questionMapper.toLeft(doc as unknown as QuestionSchemaDto));
   }
 
   async countByFormId(formId: string): Promise<number> {
@@ -65,21 +55,5 @@ export class MongoQuestionRepository implements IQuestionRepository {
 
   async deleteByFormId(formId: string): Promise<void> {
     await this.questionModel.deleteMany({ formId }).exec();
-  }
-
-  private toEntity(doc: QuestionDocument): QuestionEntity {
-    return QuestionEntity.reconstitute({
-      id: QuestionId.from(doc._id as string),
-      formId: doc.formId,
-      organizationId: doc.organizationId,
-      type: QuestionType.from(doc.type),
-      label: doc.label,
-      description: doc.description,
-      required: doc.required,
-      order: doc.order,
-      options: doc.options,
-      validation: doc.validation,
-      createdAt: doc.createdAt,
-    });
   }
 }

--- a/formix-backend/src/modules/forms/infra/repositories/question.mapper.ts
+++ b/formix-backend/src/modules/forms/infra/repositories/question.mapper.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { BidirectionalMapper } from '@shared/bidirectional-mapper';
+import { QuestionEntity } from '@modules/forms/domain/aggregate/question.entity';
+import { QuestionId } from '@modules/forms/domain/aggregate/value-objects/question-id.vo';
+import { QuestionType } from '@modules/forms/domain/aggregate/value-objects/question-type.vo';
+
+export interface QuestionSchemaDto {
+  _id: string;
+  formId: string;
+  organizationId: string;
+  type: string;
+  label: string;
+  description?: string;
+  required: boolean;
+  order: number;
+  options?: string[];
+  validation?: { min?: number; max?: number; pattern?: string };
+  createdAt: Date;
+}
+
+@Injectable()
+export class QuestionMapper implements BidirectionalMapper<QuestionEntity, QuestionSchemaDto> {
+  toRight(question: QuestionEntity): QuestionSchemaDto {
+    return {
+      _id: question.id.getValue(),
+      formId: question.formId,
+      organizationId: question.organizationId,
+      type: question.type.getValue(),
+      label: question.label,
+      description: question.description,
+      required: question.required,
+      order: question.order,
+      options: question.options,
+      validation: question.validation,
+      createdAt: question.createdAt,
+    };
+  }
+
+  toLeft(dto: QuestionSchemaDto): QuestionEntity {
+    return QuestionEntity.reconstitute({
+      id: QuestionId.from(dto._id),
+      formId: dto.formId,
+      organizationId: dto.organizationId,
+      type: QuestionType.from(dto.type),
+      label: dto.label,
+      description: dto.description,
+      required: dto.required,
+      order: dto.order,
+      options: dto.options,
+      validation: dto.validation,
+      createdAt: dto.createdAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/domain/repositories/response.repository.ts
+++ b/formix-backend/src/modules/responses/domain/repositories/response.repository.ts
@@ -4,13 +4,16 @@ import { Output } from '@shared/output';
 export interface FindByFormIdOptions {
   limit?: number;
   offset?: number;
+  search?: string;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
 }
 
 export interface IResponseRepository {
   save(response: ResponseAggregate): Promise<void>;
   findByFormId(formId: string, options?: FindByFormIdOptions): Promise<ResponseAggregate[]>;
   findAllByFormId(formId: string): Promise<ResponseAggregate[]>;
-  countByFormId(formId: string): Promise<number>;
+  countByFormId(formId: string, search?: string): Promise<number>;
   deleteByFormId(formId: string): Promise<void>;
 }
 

--- a/formix-backend/src/modules/responses/domain/usecases/expire-form.usecase.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/expire-form.usecase.ts
@@ -1,0 +1,55 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IFormRepository, FORM_REPOSITORY } from '@modules/forms/domain/repositories/form.repository';
+import { FormId } from '@modules/forms/domain/aggregate/value-objects/form-id.vo';
+import { IResponseRepository, RESPONSE_REPOSITORY } from '../repositories/response.repository';
+import { IResponseEmailRepository, RESPONSE_EMAIL_REPOSITORY } from '../repositories/response-email.repository';
+import { Output } from '@shared/output';
+
+export interface ExpireFormInput {
+  organizationId: string;
+  formId: string;
+}
+
+export interface ExpireFormOutput {
+  expired: boolean;
+}
+
+@Injectable()
+export class ExpireFormUseCase {
+  constructor(
+    @Inject(FORM_REPOSITORY) private readonly formRepository: IFormRepository,
+    @Inject(RESPONSE_REPOSITORY) private readonly responseRepository: IResponseRepository,
+    @Inject(RESPONSE_EMAIL_REPOSITORY) private readonly responseEmailRepository: IResponseEmailRepository,
+  ) {}
+
+  async execute(input: ExpireFormInput): Promise<Output<ExpireFormOutput>> {
+    let formId: FormId;
+    try {
+      formId = FormId.from(input.formId);
+    } catch {
+      return Output.fail('Form not found');
+    }
+
+    const formResult = await this.formRepository.findById(formId);
+    if (formResult.isFailure) {
+      return Output.fail('Form not found');
+    }
+
+    const form = formResult.value;
+    if (form.organizationId !== input.organizationId) {
+      return Output.fail('Form not found');
+    }
+
+    if (!form.status.isActive()) {
+      return Output.fail('Form is not active');
+    }
+
+    form.unpublish();
+    await this.formRepository.save(form);
+
+    await this.responseRepository.deleteByFormId(input.formId);
+    await this.responseEmailRepository.deleteByFormId(input.formId);
+
+    return Output.ok({ expired: true });
+  }
+}

--- a/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.ts
+++ b/formix-backend/src/modules/responses/domain/usecases/list-responses.usecase.ts
@@ -10,6 +10,9 @@ export interface ListResponsesInput {
   formId: string;
   offset?: number;
   limit?: number;
+  search?: string;
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
 }
 
 export interface ResponseDto {
@@ -52,8 +55,14 @@ export class ListResponsesUseCase {
     const limit = input.limit ?? 20;
 
     const [responses, total] = await Promise.all([
-      this.responseRepository.findByFormId(input.formId, { offset, limit }),
-      this.responseRepository.countByFormId(input.formId),
+      this.responseRepository.findByFormId(input.formId, {
+        offset,
+        limit,
+        search: input.search,
+        sortBy: input.sortBy,
+        sortDir: input.sortDir,
+      }),
+      this.responseRepository.countByFormId(input.formId, input.search),
     ]);
 
     return Output.ok({

--- a/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/responses.controller.ts
@@ -5,6 +5,7 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  HttpCode,
   NotFoundException,
   Param,
   Post,
@@ -23,6 +24,7 @@ import { Public } from '@modules/auth/infra/decorators/public.decorator';
 import { CurrentUser, JwtPayload } from '@modules/auth/infra/decorators/current-user.decorator';
 import { SubmitResponseUseCase } from '@modules/responses/domain/usecases/submit-response.usecase';
 import { ListResponsesUseCase } from '@modules/responses/domain/usecases/list-responses.usecase';
+import { ExpireFormUseCase } from '@modules/responses/domain/usecases/expire-form.usecase';
 import { GetPublicFormUseCase } from '@modules/forms/domain/usecases/get-public-form.usecase';
 import { SubmitResponseDto, SubmitResponseResponseDto } from './submit-response.dto';
 
@@ -33,6 +35,7 @@ export class ResponsesController {
     private readonly submitResponseUseCase: SubmitResponseUseCase,
     private readonly listResponsesUseCase: ListResponsesUseCase,
     private readonly getPublicFormUseCase: GetPublicFormUseCase,
+    private readonly expireFormUseCase: ExpireFormUseCase,
   ) {}
 
   @Get('forms/public/:publicToken')
@@ -78,12 +81,42 @@ export class ResponsesController {
     return output.value;
   }
 
+  @Post('forms/:id/expire')
+  @HttpCode(200)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Expire a form: unpublish it and delete all responses' })
+  @ApiParam({ name: 'id', description: 'Form ID' })
+  @ApiResponse({ status: 200, description: 'Form expired and responses deleted' })
+  @ApiResponse({ status: 400, description: 'Form is not active' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Form not found' })
+  async expireForm(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<{ expired: boolean }> {
+    const output = await this.expireFormUseCase.execute({
+      organizationId: user.organizationId,
+      formId: id,
+    });
+
+    if (output.isFailure) {
+      const msg = output.errorMessage;
+      if (msg.includes('not found')) throw new NotFoundException(msg);
+      throw new BadRequestException(msg);
+    }
+
+    return output.value;
+  }
+
   @Get('forms/:id/responses')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'List paginated responses for a form' })
   @ApiParam({ name: 'id', description: 'Form ID' })
   @ApiQuery({ name: 'offset', required: false, description: 'Pagination offset (default: 0)' })
   @ApiQuery({ name: 'limit', required: false, description: 'Number of results (default: 20)' })
+  @ApiQuery({ name: 'search', required: false, description: 'Search term across answer values' })
+  @ApiQuery({ name: 'sortBy', required: false, description: 'Sort column: "date" or a questionId' })
+  @ApiQuery({ name: 'sortDir', required: false, description: 'Sort direction: "asc" or "desc"' })
   @ApiResponse({ status: 200, description: 'Paginated list of responses' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden — form belongs to another organization' })
@@ -93,12 +126,18 @@ export class ResponsesController {
     @CurrentUser() user: JwtPayload,
     @Query('offset') offset?: string,
     @Query('limit') limit?: string,
+    @Query('search') search?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortDir') sortDir?: string,
   ) {
     const output = await this.listResponsesUseCase.execute({
       organizationId: user.organizationId,
       formId,
       offset: offset ? parseInt(offset, 10) : 0,
       limit: limit ? parseInt(limit, 10) : 20,
+      search: search || undefined,
+      sortBy: sortBy || undefined,
+      sortDir: sortDir === 'asc' || sortDir === 'desc' ? sortDir : undefined,
     });
 
     if (output.isFailure) {

--- a/formix-backend/src/modules/responses/infra/controllers/submit-response.dto.ts
+++ b/formix-backend/src/modules/responses/infra/controllers/submit-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsEmail, IsString, ValidateNested } from 'class-validator';
+import { Allow, IsArray, IsEmail, IsString, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class AnswerDto {
@@ -8,6 +8,7 @@ export class AnswerDto {
   questionId: string;
 
   @ApiProperty({ example: 'My answer', description: 'Answer value (any type depending on question type)' })
+  @Allow()
   value: unknown;
 }
 

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.test.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { MongoResponseEmailRepository } from './mongo-response-email.repository';
+import { ResponseEmailMapper } from './response-email.mapper';
 import { ResponseEmailSchemaClass, ResponseEmailSchema } from '../schemas/response-email.schema';
 import { ResponseEmailAggregate } from '@modules/responses/domain/aggregate/response-email.aggregate';
 
@@ -19,7 +20,7 @@ describe('MongoResponseEmailRepository (integration)', () => {
           { name: ResponseEmailSchemaClass.name, schema: ResponseEmailSchema },
         ]),
       ],
-      providers: [MongoResponseEmailRepository],
+      providers: [ResponseEmailMapper, MongoResponseEmailRepository],
     }).compile();
 
     repo = module.get(MongoResponseEmailRepository);

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response-email.repository.ts
@@ -3,32 +3,31 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { IResponseEmailRepository } from '@modules/responses/domain/repositories/response-email.repository';
 import { ResponseEmailAggregate } from '@modules/responses/domain/aggregate/response-email.aggregate';
-import { ResponseEmailId } from '@modules/responses/domain/aggregate/value-objects/response-email-id.vo';
 import {
   ResponseEmailDocument,
   ResponseEmailSchemaClass,
 } from '../schemas/response-email.schema';
+import { ResponseEmailMapper, ResponseEmailSchemaDto } from './response-email.mapper';
 
 @Injectable()
 export class MongoResponseEmailRepository implements IResponseEmailRepository {
   constructor(
     @InjectModel(ResponseEmailSchemaClass.name)
     private readonly responseEmailModel: Model<ResponseEmailDocument>,
+    private readonly responseEmailMapper: ResponseEmailMapper,
   ) {}
 
   async save(responseEmail: ResponseEmailAggregate): Promise<void> {
-    await this.responseEmailModel.findOneAndUpdate(
-      { _id: responseEmail.id.getValue() },
-      {
-        $set: {
-          formId: responseEmail.formId,
-          emailHash: responseEmail.emailHash,
-          respondedAt: responseEmail.respondedAt,
-        },
-        $setOnInsert: { _id: responseEmail.id.getValue() },
-      },
-      { upsert: true },
-    );
+    const dto = this.responseEmailMapper.toRight(responseEmail);
+
+    const alreadyExists = await this.responseEmailModel.exists({ _id: dto._id });
+
+    if (!alreadyExists) {
+      await this.responseEmailModel.create(dto);
+      return;
+    }
+
+    await this.responseEmailModel.replaceOne({ _id: dto._id }, dto);
   }
 
   async existsByFormIdAndEmailHash(formId: string, emailHash: string): Promise<boolean> {
@@ -38,14 +37,5 @@ export class MongoResponseEmailRepository implements IResponseEmailRepository {
 
   async deleteByFormId(formId: string): Promise<void> {
     await this.responseEmailModel.deleteMany({ formId }).exec();
-  }
-
-  private toEntity(doc: ResponseEmailDocument): ResponseEmailAggregate {
-    return ResponseEmailAggregate.reconstitute({
-      id: ResponseEmailId.from(doc._id as string),
-      formId: doc.formId,
-      emailHash: doc.emailHash,
-      respondedAt: doc.respondedAt,
-    });
   }
 }

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.test.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.test.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { MongoResponseRepository } from './mongo-response.repository';
+import { ResponseMapper } from './response.mapper';
 import { ResponseSchemaClass, ResponseSchema } from '../schemas/response.schema';
 import { ResponseAggregate } from '@modules/responses/domain/aggregate/response.aggregate';
 
@@ -24,7 +25,7 @@ describe('MongoResponseRepository (integration)', () => {
         MongooseModule.forRoot(mongod.getUri()),
         MongooseModule.forFeature([{ name: ResponseSchemaClass.name, schema: ResponseSchema }]),
       ],
-      providers: [MongoResponseRepository],
+      providers: [ResponseMapper, MongoResponseRepository],
     }).compile();
 
     repo = module.get(MongoResponseRepository);

--- a/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/mongo-response.repository.ts
@@ -1,75 +1,116 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, PipelineStage } from 'mongoose';
 import {
   IResponseRepository,
   FindByFormIdOptions,
 } from '@modules/responses/domain/repositories/response.repository';
 import { ResponseAggregate } from '@modules/responses/domain/aggregate/response.aggregate';
-import { ResponseId } from '@modules/responses/domain/aggregate/value-objects/response-id.vo';
 import { ResponseDocument, ResponseSchemaClass } from '../schemas/response.schema';
+import { ResponseMapper, ResponseSchemaDto } from './response.mapper';
 
 @Injectable()
 export class MongoResponseRepository implements IResponseRepository {
   constructor(
     @InjectModel(ResponseSchemaClass.name)
     private readonly responseModel: Model<ResponseDocument>,
+    private readonly responseMapper: ResponseMapper,
   ) {}
 
   async save(response: ResponseAggregate): Promise<void> {
-    await this.responseModel.findOneAndUpdate(
-      { _id: response.id.getValue() },
-      {
-        $set: {
-          formId: response.formId,
-          organizationId: response.organizationId,
-          answers: response.answers,
-          submittedAt: response.submittedAt,
-        },
-        $setOnInsert: { _id: response.id.getValue() },
-      },
-      { upsert: true },
-    );
+    const dto = this.responseMapper.toRight(response);
+
+    const alreadyExists = await this.responseModel.exists({ _id: dto._id });
+
+    if (!alreadyExists) {
+      await this.responseModel.create(dto);
+      return;
+    }
+
+    await this.responseModel.replaceOne({ _id: dto._id }, dto);
   }
 
   async findByFormId(formId: string, options?: FindByFormIdOptions): Promise<ResponseAggregate[]> {
     const limit = options?.limit ?? 20;
     const offset = options?.offset ?? 0;
+    const search = options?.search?.trim();
+    const sortBy = options?.sortBy ?? 'date';
+    const sortDir: 1 | -1 = options?.sortDir === 'asc' ? 1 : -1;
+
+    const pipeline: PipelineStage[] = [];
+
+    const matchStage: Record<string, unknown> = { formId };
+    if (search) {
+      matchStage['$or'] = [{ 'answers.value': { $regex: search, $options: 'i' } }];
+    }
+    pipeline.push({ $match: matchStage });
+
+    if (sortBy === 'date') {
+      pipeline.push({ $sort: { submittedAt: sortDir } });
+    } else {
+      pipeline.push({
+        $addFields: {
+          _sortValue: {
+            $arrayElemAt: [
+              {
+                $map: {
+                  input: {
+                    $filter: {
+                      input: '$answers',
+                      cond: { $eq: ['$$this.questionId', sortBy] },
+                    },
+                  },
+                  as: 'ans',
+                  in: '$$ans.value',
+                },
+              },
+              0,
+            ],
+          },
+        },
+      });
+      pipeline.push({ $sort: { _sortValue: sortDir } });
+      pipeline.push({ $project: { _sortValue: 0 } });
+    }
+
+    pipeline.push({ $skip: offset });
+    pipeline.push({ $limit: limit });
 
     const docs = await this.responseModel
-      .find({ formId })
-      .sort({ submittedAt: -1 })
-      .skip(offset)
-      .limit(limit)
+      .aggregate<ResponseSchemaDto>(pipeline)
       .exec();
 
-    return docs.map(this.toEntity);
+    return docs.map((doc) => this.responseMapper.toLeft(doc));
   }
 
   async findAllByFormId(formId: string): Promise<ResponseAggregate[]> {
     const docs = await this.responseModel
       .find({ formId })
       .sort({ submittedAt: 1 })
+      .lean()
       .exec();
 
-    return docs.map(this.toEntity);
+    return docs.map((doc) => this.responseMapper.toLeft(doc as unknown as ResponseSchemaDto));
   }
 
-  async countByFormId(formId: string): Promise<number> {
-    return this.responseModel.countDocuments({ formId }).exec();
+  async countByFormId(formId: string, search?: string): Promise<number> {
+    const match: Record<string, unknown> = { formId };
+    if (search?.trim()) {
+      match['$or'] = [{ 'answers.value': { $regex: search.trim(), $options: 'i' } }];
+    }
+
+    if (!search?.trim()) {
+      return this.responseModel.countDocuments({ formId }).exec();
+    }
+
+    const result = await this.responseModel
+      .aggregate<{ total: number }>([{ $match: match }, { $count: 'total' }])
+      .exec();
+
+    return result[0]?.total ?? 0;
   }
 
   async deleteByFormId(formId: string): Promise<void> {
     await this.responseModel.deleteMany({ formId }).exec();
-  }
-
-  private toEntity(doc: ResponseDocument): ResponseAggregate {
-    return ResponseAggregate.reconstitute({
-      id: ResponseId.from(doc._id as string),
-      formId: doc.formId,
-      organizationId: doc.organizationId,
-      answers: doc.answers,
-      submittedAt: doc.submittedAt,
-    });
   }
 }

--- a/formix-backend/src/modules/responses/infra/repositories/response-email.mapper.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/response-email.mapper.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { BidirectionalMapper } from '@shared/bidirectional-mapper';
+import { ResponseEmailAggregate } from '@modules/responses/domain/aggregate/response-email.aggregate';
+import { ResponseEmailId } from '@modules/responses/domain/aggregate/value-objects/response-email-id.vo';
+
+export interface ResponseEmailSchemaDto {
+  _id: string;
+  formId: string;
+  emailHash: string;
+  respondedAt: Date;
+}
+
+@Injectable()
+export class ResponseEmailMapper
+  implements BidirectionalMapper<ResponseEmailAggregate, ResponseEmailSchemaDto>
+{
+  toRight(responseEmail: ResponseEmailAggregate): ResponseEmailSchemaDto {
+    return {
+      _id: responseEmail.id.getValue(),
+      formId: responseEmail.formId,
+      emailHash: responseEmail.emailHash,
+      respondedAt: responseEmail.respondedAt,
+    };
+  }
+
+  toLeft(dto: ResponseEmailSchemaDto): ResponseEmailAggregate {
+    return ResponseEmailAggregate.reconstitute({
+      id: ResponseEmailId.from(dto._id),
+      formId: dto.formId,
+      emailHash: dto.emailHash,
+      respondedAt: dto.respondedAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/infra/repositories/response.mapper.ts
+++ b/formix-backend/src/modules/responses/infra/repositories/response.mapper.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { BidirectionalMapper } from '@shared/bidirectional-mapper';
+import { ResponseAggregate } from '@modules/responses/domain/aggregate/response.aggregate';
+import { ResponseId } from '@modules/responses/domain/aggregate/value-objects/response-id.vo';
+
+export interface ResponseSchemaDto {
+  _id: string;
+  formId: string;
+  organizationId: string;
+  answers: { questionId: string; value: unknown }[];
+  submittedAt: Date;
+}
+
+@Injectable()
+export class ResponseMapper implements BidirectionalMapper<ResponseAggregate, ResponseSchemaDto> {
+  toRight(response: ResponseAggregate): ResponseSchemaDto {
+    return {
+      _id: response.id.getValue(),
+      formId: response.formId,
+      organizationId: response.organizationId,
+      answers: response.answers,
+      submittedAt: response.submittedAt,
+    };
+  }
+
+  toLeft(dto: ResponseSchemaDto): ResponseAggregate {
+    return ResponseAggregate.reconstitute({
+      id: ResponseId.from(dto._id),
+      formId: dto.formId,
+      organizationId: dto.organizationId,
+      answers: dto.answers,
+      submittedAt: dto.submittedAt,
+    });
+  }
+}

--- a/formix-backend/src/modules/responses/responses.module.ts
+++ b/formix-backend/src/modules/responses/responses.module.ts
@@ -4,10 +4,13 @@ import { ResponseSchemaClass, ResponseSchema } from './infra/schemas/response.sc
 import { ResponseEmailSchemaClass, ResponseEmailSchema } from './infra/schemas/response-email.schema';
 import { MongoResponseRepository } from './infra/repositories/mongo-response.repository';
 import { MongoResponseEmailRepository } from './infra/repositories/mongo-response-email.repository';
+import { ResponseMapper } from './infra/repositories/response.mapper';
+import { ResponseEmailMapper } from './infra/repositories/response-email.mapper';
 import { RESPONSE_REPOSITORY } from './domain/repositories/response.repository';
 import { RESPONSE_EMAIL_REPOSITORY } from './domain/repositories/response-email.repository';
 import { SubmitResponseUseCase } from './domain/usecases/submit-response.usecase';
 import { ListResponsesUseCase } from './domain/usecases/list-responses.usecase';
+import { ExpireFormUseCase } from './domain/usecases/expire-form.usecase';
 import { ResponsesController } from './infra/controllers/responses.controller';
 import { FormsModule } from '@modules/forms/forms.module';
 
@@ -21,10 +24,13 @@ import { FormsModule } from '@modules/forms/forms.module';
   ],
   controllers: [ResponsesController],
   providers: [
+    ResponseMapper,
+    ResponseEmailMapper,
     { provide: RESPONSE_REPOSITORY, useClass: MongoResponseRepository },
     { provide: RESPONSE_EMAIL_REPOSITORY, useClass: MongoResponseEmailRepository },
     SubmitResponseUseCase,
     ListResponsesUseCase,
+    ExpireFormUseCase,
   ],
   exports: [RESPONSE_REPOSITORY, RESPONSE_EMAIL_REPOSITORY],
 })

--- a/formix-backend/src/providers/email/email-templates.ts
+++ b/formix-backend/src/providers/email/email-templates.ts
@@ -1,0 +1,248 @@
+import { EmailTemplate } from './email.provider';
+
+const BASE_STYLES = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background-color: #f1f5f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; -webkit-font-smoothing: antialiased; }
+`;
+
+function layout(content: string): string {
+  return `
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>${BASE_STYLES}</style>
+</head>
+<body>
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9; padding: 40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;">
+
+          <!-- Logo -->
+          <tr>
+            <td align="center" style="padding-bottom: 24px;">
+              <table cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background:#6366f1; border-radius:12px; padding: 10px 20px;">
+                    <span style="color:#ffffff; font-size:22px; font-weight:700; letter-spacing:-0.5px;">Formix</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td style="background:#ffffff; border-radius:16px; padding:40px 40px 32px; box-shadow:0 1px 3px rgba(0,0,0,0.07);">
+              ${content}
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding-top: 24px;">
+              <p style="color:#94a3b8; font-size:12px; line-height:1.6;">
+                Este email foi enviado automaticamente pelo Formix.<br/>
+                Por favor, não responda a este email.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+  `.trim();
+}
+
+function ctaButton(label: string, url: string): string {
+  return `
+    <table cellpadding="0" cellspacing="0" style="margin: 32px auto 0;">
+      <tr>
+        <td align="center" style="background:#6366f1; border-radius:8px;">
+          <a href="${url}" target="_blank"
+            style="display:inline-block; padding:14px 32px; color:#ffffff; font-size:15px; font-weight:600; text-decoration:none; letter-spacing:0.1px;">
+            ${label}
+          </a>
+        </td>
+      </tr>
+    </table>
+  `;
+}
+
+function fallbackLink(url: string): string {
+  return `
+    <p style="margin-top:24px; font-size:12px; color:#94a3b8; text-align:center; word-break:break-all;">
+      Se o botão não funcionar, copie e cole este link no navegador:<br/>
+      <a href="${url}" style="color:#6366f1;">${url}</a>
+    </p>
+  `;
+}
+
+// ─── Templates ────────────────────────────────────────────────────────────────
+
+function emailConfirmationHtml(data: Record<string, unknown>): string {
+  const url = String(data.confirmationUrl ?? '#');
+  const firstName = data.name ? String(data.name).split(' ')[0] : null;
+  const greeting = firstName ? `Olá, <strong style="color:#0f172a;">${firstName}</strong>!` : 'Olá!';
+  return layout(`
+    <!-- Icon -->
+    <div style="text-align:center; margin-bottom:24px;">
+      <div style="display:inline-flex; align-items:center; justify-content:center; width:64px; height:64px; background:#ede9fe; border-radius:50%;">
+        <span style="font-size:28px;">✉️</span>
+      </div>
+    </div>
+
+    <!-- Title -->
+    <h1 style="text-align:center; color:#0f172a; font-size:22px; font-weight:700; margin-bottom:12px;">
+      Confirme seu e-mail
+    </h1>
+
+    <!-- Body -->
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7; margin-bottom:8px;">
+      ${greeting} Bem-vindo ao <strong style="color:#6366f1;">Formix</strong>!
+    </p>
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7;">
+      Sua conta foi criada com sucesso. Clique no botão abaixo para confirmar seu e-mail e ativar sua conta.
+    </p>
+
+    ${ctaButton('Confirmar e-mail', url)}
+
+    <!-- Expiration note -->
+    <p style="margin-top:20px; text-align:center; font-size:13px; color:#94a3b8;">
+      Este link expira em <strong>24 horas</strong>.
+    </p>
+
+    ${fallbackLink(url)}
+
+    <!-- Divider -->
+    <hr style="border:none; border-top:1px solid #e2e8f0; margin:28px 0;" />
+
+    <p style="font-size:12px; color:#94a3b8; text-align:center;">
+      Se você não criou esta conta, pode ignorar este e-mail com segurança.
+    </p>
+  `);
+}
+
+function invitationHtml(data: Record<string, unknown>): string {
+  const url = String(data.inviteUrl ?? data.inviteLink ?? '#');
+  const inviterName = String(data.inviterName ?? data.inviteeName ?? 'Um membro da equipe');
+  const organizationName = String(data.organizationName ?? 'uma organização');
+  return layout(`
+    <!-- Icon -->
+    <div style="text-align:center; margin-bottom:24px;">
+      <div style="display:inline-flex; align-items:center; justify-content:center; width:64px; height:64px; background:#ede9fe; border-radius:50%;">
+        <span style="font-size:28px;">🎉</span>
+      </div>
+    </div>
+
+    <!-- Title -->
+    <h1 style="text-align:center; color:#0f172a; font-size:22px; font-weight:700; margin-bottom:12px;">
+      Você foi convidado!
+    </h1>
+
+    <!-- Body -->
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7; margin-bottom:8px;">
+      <strong style="color:#0f172a;">${inviterName}</strong> convidou você para fazer parte de
+    </p>
+
+    <!-- Organization highlight -->
+    <div style="text-align:center; margin:16px 0 8px;">
+      <div style="display:inline-block; background:#f5f3ff; border:1px solid #ddd6fe; border-radius:10px; padding:10px 24px;">
+        <span style="color:#6366f1; font-size:17px; font-weight:700;">${organizationName}</span>
+      </div>
+    </div>
+
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7; margin-top:12px;">
+      Aceite o convite e comece a colaborar na criação de formulários e análise de respostas.
+    </p>
+
+    ${ctaButton('Aceitar convite', url)}
+
+    <!-- Expiration note -->
+    <p style="margin-top:20px; text-align:center; font-size:13px; color:#94a3b8;">
+      Este convite expira em <strong>7 dias</strong>.
+    </p>
+
+    ${fallbackLink(url)}
+
+    <!-- Divider -->
+    <hr style="border:none; border-top:1px solid #e2e8f0; margin:28px 0;" />
+
+    <p style="font-size:12px; color:#94a3b8; text-align:center;">
+      Se você não esperava este convite, pode ignorar este e-mail com segurança.
+    </p>
+  `);
+}
+
+function passwordResetHtml(data: Record<string, unknown>): string {
+  const url = String(data.resetUrl ?? '#');
+  return layout(`
+    <!-- Icon -->
+    <div style="text-align:center; margin-bottom:24px;">
+      <div style="display:inline-flex; align-items:center; justify-content:center; width:64px; height:64px; background:#ede9fe; border-radius:50%;">
+        <span style="font-size:28px;">🔑</span>
+      </div>
+    </div>
+
+    <!-- Title -->
+    <h1 style="text-align:center; color:#0f172a; font-size:22px; font-weight:700; margin-bottom:12px;">
+      Redefinição de senha
+    </h1>
+
+    <!-- Body -->
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7; margin-bottom:8px;">
+      Recebemos uma solicitação para redefinir a senha da sua conta no <strong style="color:#6366f1;">Formix</strong>.
+    </p>
+    <p style="text-align:center; color:#64748b; font-size:15px; line-height:1.7;">
+      Clique no botão abaixo para criar uma nova senha.
+    </p>
+
+    ${ctaButton('Redefinir senha', url)}
+
+    <!-- Expiration note -->
+    <p style="margin-top:20px; text-align:center; font-size:13px; color:#94a3b8;">
+      Este link expira em <strong>1 hora</strong>.
+    </p>
+
+    ${fallbackLink(url)}
+
+    <!-- Divider -->
+    <hr style="border:none; border-top:1px solid #e2e8f0; margin:28px 0;" />
+
+    <!-- Security warning -->
+    <div style="background:#fff7ed; border:1px solid #fed7aa; border-radius:8px; padding:14px 18px;">
+      <p style="font-size:13px; color:#92400e; line-height:1.6;">
+        ⚠️ <strong>Não solicitou isso?</strong> Ignore este e-mail. Sua senha não será alterada.
+        Se isso parecer suspeito, entre em contato com o suporte.
+      </p>
+    </div>
+  `);
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+export const EMAIL_HTML_TEMPLATES: Record<
+  EmailTemplate,
+  { subject: string; buildHtml: (data: Record<string, unknown>) => string; buildText: (data: Record<string, unknown>) => string }
+> = {
+  [EmailTemplate.EMAIL_CONFIRMATION]: {
+    subject: 'Confirme seu e-mail — Formix',
+    buildHtml: emailConfirmationHtml,
+    buildText: (data) => `Confirme seu e-mail no Formix:\n${data.confirmationUrl}`,
+  },
+  [EmailTemplate.INVITATION]: {
+    subject: 'Você foi convidado para o Formix',
+    buildHtml: invitationHtml,
+    buildText: (data) => `Você foi convidado para ${data.organizationName}.\nAceite o convite: ${data.inviteLink ?? data.inviteUrl}`,
+  },
+  [EmailTemplate.PASSWORD_RESET]: {
+    subject: 'Redefinição de senha — Formix',
+    buildHtml: passwordResetHtml,
+    buildText: (data) => `Redefina sua senha no Formix:\n${data.resetUrl}`,
+  },
+};

--- a/formix-backend/src/providers/email/email.module.ts
+++ b/formix-backend/src/providers/email/email.module.ts
@@ -3,20 +3,28 @@ import { ConfigService } from '@nestjs/config';
 import { EMAIL_SERVICE, IEmailService } from '@providers/email/email.provider';
 import { ConsoleEmailService } from './implementations/console/console.implementation';
 import { MailtrapEmailService } from './implementations/mailtrap/mailtrap.implementation';
+import { EtherealEmailService } from './implementations/ethereal/ethereal.implementation';
 
 @Global()
 @Module({
   providers: [
     ConsoleEmailService,
     MailtrapEmailService,
+    EtherealEmailService,
     {
       provide: EMAIL_SERVICE,
-      useFactory: (config: ConfigService, console: ConsoleEmailService, mailtrap: MailtrapEmailService): IEmailService => {
+      useFactory: (
+        config: ConfigService,
+        console: ConsoleEmailService,
+        mailtrap: MailtrapEmailService,
+        ethereal: EtherealEmailService
+      ): IEmailService => {
         const provider = config.get<string>('EMAIL_PROVIDER', 'console');
         if (provider === 'mailtrap') return mailtrap;
+        if (provider === 'ethereal') return ethereal;
         return console;
       },
-      inject: [ConfigService, ConsoleEmailService, MailtrapEmailService],
+      inject: [ConfigService, ConsoleEmailService, MailtrapEmailService, EtherealEmailService],
     },
   ],
   exports: [EMAIL_SERVICE],

--- a/formix-backend/src/providers/email/implementations/ethereal/ethereal.implementation.ts
+++ b/formix-backend/src/providers/email/implementations/ethereal/ethereal.implementation.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import { EmailTemplate, IEmailService } from '@providers/email/email.provider';
+import { EMAIL_HTML_TEMPLATES } from '@providers/email/email-templates';
+
+@Injectable()
+export class EtherealEmailService implements IEmailService {
+  private readonly logger = new Logger(EtherealEmailService.name);
+  private transporter: nodemailer.Transporter | null = null;
+
+  constructor(private readonly config: ConfigService) {}
+
+  private async getTransporter(): Promise<nodemailer.Transporter> {
+    if (!this.transporter) {
+      const testAccount = await nodemailer.createTestAccount();
+      this.logger.log(`Ethereal test account: ${testAccount.user} / ${testAccount.pass}`);
+      this.transporter = nodemailer.createTransport({
+        host: 'smtp.ethereal.email',
+        port: 587,
+        secure: false,
+        auth: {
+          user: testAccount.user,
+          pass: testAccount.pass,
+        },
+      });
+    }
+    return this.transporter;
+  }
+
+  async send(to: string, template: EmailTemplate, data: Record<string, unknown>): Promise<void> {
+    const { subject, buildHtml, buildText } = EMAIL_HTML_TEMPLATES[template];
+    const transporter = await this.getTransporter();
+
+    const info = await transporter.sendMail({
+      from: this.config.get<string>('EMAIL_FROM', 'noreply@formix.app'),
+      to,
+      subject,
+      text: buildText(data),
+      html: buildHtml(data),
+    });
+
+    const previewUrl = nodemailer.getTestMessageUrl(info);
+    this.logger.log(`Email enviado para ${to} | Template: ${template}`);
+    this.logger.log(`Preview URL: ${previewUrl}`);
+  }
+}

--- a/formix-backend/src/providers/email/implementations/mailtrap/mailtrap.implementation.ts
+++ b/formix-backend/src/providers/email/implementations/mailtrap/mailtrap.implementation.ts
@@ -2,21 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import { EmailTemplate, IEmailService } from '@providers/email/email.provider';
-
-const TEMPLATES: Record<EmailTemplate, { subject: string; buildText: (data: Record<string, unknown>) => string }> = {
-  [EmailTemplate.EMAIL_CONFIRMATION]: {
-    subject: 'Confirme seu e-mail',
-    buildText: (data) => `Acesse o link para confirmar seu e-mail: ${data.confirmationUrl}`,
-  },
-  [EmailTemplate.INVITATION]: {
-    subject: 'Você foi convidado',
-    buildText: (data) => `Acesse o link para aceitar o convite: ${data.inviteUrl}`,
-  },
-  [EmailTemplate.PASSWORD_RESET]: {
-    subject: 'Redefinição de senha',
-    buildText: (data) => `Acesse o link para redefinir sua senha: ${data.resetUrl}`,
-  },
-};
+import { EMAIL_HTML_TEMPLATES } from '@providers/email/email-templates';
 
 @Injectable()
 export class MailtrapEmailService implements IEmailService {
@@ -34,13 +20,14 @@ export class MailtrapEmailService implements IEmailService {
   }
 
   async send(to: string, template: EmailTemplate, data: Record<string, unknown>): Promise<void> {
-    const { subject, buildText } = TEMPLATES[template];
+    const { subject, buildHtml, buildText } = EMAIL_HTML_TEMPLATES[template];
 
     await this.transporter.sendMail({
       from: this.config.get<string>('EMAIL_FROM', 'noreply@formix.app'),
       to,
       subject,
       text: buildText(data),
+      html: buildHtml(data),
     });
   }
 }

--- a/formix-backend/src/shared/bidirectional-mapper.ts
+++ b/formix-backend/src/shared/bidirectional-mapper.ts
@@ -1,0 +1,4 @@
+export interface BidirectionalMapper<L, R> {
+  toRight(left: L): R;
+  toLeft(right: R): L;
+}

--- a/formix-frontend/package-lock.json
+++ b/formix-frontend/package-lock.json
@@ -18,6 +18,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
         "next": "^16.1.7",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -6626,6 +6627,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/node-exports-info": {

--- a/formix-frontend/package.json
+++ b/formix-frontend/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "^16.1.7",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/formix-frontend/src/app/(app)/forms/[id]/responses/page.tsx
+++ b/formix-frontend/src/app/(app)/forms/[id]/responses/page.tsx
@@ -1,16 +1,25 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { ArrowUp, ArrowDown, ArrowUpDown, Search, X } from 'lucide-react';
 import { PageContainer } from '@/components/Layout';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { getForm } from '@/services/forms/forms.service';
 import { listResponses } from '@/services/responses/responses.service';
 import type { FormDetail } from '@/services/forms/forms.types';
 import type { ListResponsesOutput } from '@/services/responses/responses.types';
 
-const DEFAULT_LIMIT = 20;
+const PAGE_SIZE = 20;
+
+type SortDirection = 'asc' | 'desc';
+
+interface SortState {
+  column: string;
+  direction: SortDirection;
+}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString('pt-BR', {
@@ -28,42 +37,85 @@ function getAnswerValue(answers: { questionId: string; value: unknown }[], quest
   return String(answer.value);
 }
 
+function SortIcon({ column, sort }: { column: string; sort: SortState }) {
+  if (sort.column !== column) return <ArrowUpDown className="size-3.5 ml-1 shrink-0 text-muted-foreground/50" />;
+  if (sort.direction === 'asc') return <ArrowUp className="size-3.5 ml-1 shrink-0 text-violet-600" />;
+  return <ArrowDown className="size-3.5 ml-1 shrink-0 text-violet-600" />;
+}
+
 export default function FormResponsesPage() {
   const { id } = useParams<{ id: string }>();
 
   const [form, setForm] = useState<FormDetail | null>(null);
   const [data, setData] = useState<ListResponsesOutput | null>(null);
-  const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [sort, setSort] = useState<SortState>({ column: 'date', direction: 'desc' });
+  const [page, setPage] = useState(1);
+
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const load = useCallback(
-    async (newOffset: number) => {
+    async (params: { page: number; search: string; sort: SortState; form: FormDetail | null }) => {
       setLoading(true);
       try {
+        const offset = (params.page - 1) * PAGE_SIZE;
         const [formData, responsesData] = await Promise.all([
-          form ? Promise.resolve(form) : getForm(id),
-          listResponses(id, newOffset, DEFAULT_LIMIT),
+          params.form ? Promise.resolve(params.form) : getForm(id),
+          listResponses(id, offset, PAGE_SIZE, params.search || undefined, params.sort.column, params.sort.direction),
         ]);
         setForm(formData);
         setData(responsesData);
-        setOffset(newOffset);
       } catch {
         setError('Erro ao carregar respostas.');
       } finally {
         setLoading(false);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [id],
   );
 
   useEffect(() => {
-    load(0);
-  }, [load]);
+    load({ page: 1, search: '', sort: { column: 'date', direction: 'desc' }, form: null });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const totalPages = data ? Math.ceil(data.total / DEFAULT_LIMIT) : 0;
-  const currentPage = Math.floor(offset / DEFAULT_LIMIT) + 1;
+  function handleSearchInput(val: string) {
+    setSearchInput(val);
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => {
+      setSearch(val);
+      setPage(1);
+      load({ page: 1, search: val, sort, form });
+    }, 400);
+  }
+
+  function handleClearSearch() {
+    setSearchInput('');
+    setSearch('');
+    setPage(1);
+    load({ page: 1, search: '', sort, form });
+  }
+
+  function handleSort(column: string) {
+    const newSort: SortState = sort.column === column
+      ? { column, direction: sort.direction === 'asc' ? 'desc' : 'asc' }
+      : { column, direction: 'asc' };
+    setSort(newSort);
+    setPage(1);
+    load({ page: 1, search, sort: newSort, form });
+  }
+
+  function handlePage(newPage: number) {
+    setPage(newPage);
+    load({ page: newPage, search, sort, form });
+  }
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / PAGE_SIZE)) : 1;
+  const orderedQuestions = form?.questions.slice().sort((a, b) => a.order - b.order) ?? [];
 
   return (
     <PageContainer>
@@ -73,7 +125,8 @@ export default function FormResponsesPage() {
             <h1 className="text-2xl font-bold">{form?.title ?? 'Respostas'}</h1>
             {data && (
               <p className="text-sm text-muted-foreground">
-                {data.total} {data.total === 1 ? 'resposta' : 'respostas'} no total
+                {data.total} {data.total === 1 ? 'resposta' : 'respostas'}
+                {search && <span className="ml-1">encontrada{data.total !== 1 ? 's' : ''} para &quot;{search}&quot;</span>}
               </p>
             )}
           </div>
@@ -84,29 +137,63 @@ export default function FormResponsesPage() {
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <Input
+            value={searchInput}
+            onChange={(e) => handleSearchInput(e.target.value)}
+            placeholder="Buscar em qualquer coluna..."
+            className="pl-9 pr-9"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={handleClearSearch}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+
         {loading ? (
           <p className="text-muted-foreground">Carregando...</p>
         ) : data?.responses.length === 0 ? (
           <div className="rounded-lg border p-8 text-center">
-            <p className="text-muted-foreground">Nenhuma resposta recebida ainda.</p>
+            <p className="text-muted-foreground">
+              {search ? `Nenhuma resposta encontrada para "${search}".` : 'Nenhuma resposta recebida ainda.'}
+            </p>
           </div>
         ) : (
           <div className="overflow-x-auto rounded-lg border">
             <table className="w-full text-sm">
               <thead className="bg-muted/50">
                 <tr>
-                  <th className="whitespace-nowrap px-4 py-3 text-left font-medium">Data</th>
-                  {form?.questions
-                    .slice()
-                    .sort((a, b) => a.order - b.order)
-                    .map((q) => (
-                      <th
-                        key={q.id}
-                        className="whitespace-nowrap px-4 py-3 text-left font-medium max-w-[200px]"
+                  <th className="whitespace-nowrap px-4 py-3 text-left font-medium">
+                    <button
+                      type="button"
+                      onClick={() => handleSort('date')}
+                      className="flex items-center hover:text-violet-600 transition-colors"
+                    >
+                      Data
+                      <SortIcon column="date" sort={sort} />
+                    </button>
+                  </th>
+                  {orderedQuestions.map((q) => (
+                    <th
+                      key={q.id}
+                      className="whitespace-nowrap px-4 py-3 text-left font-medium max-w-[200px]"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleSort(q.id)}
+                        className="flex items-center hover:text-violet-600 transition-colors"
                       >
-                        {q.label}
-                      </th>
-                    ))}
+                        <span className="truncate max-w-[160px]">{q.label}</span>
+                        <SortIcon column={q.id} sort={sort} />
+                      </button>
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody className="divide-y">
@@ -115,18 +202,15 @@ export default function FormResponsesPage() {
                     <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
                       {formatDate(row.submittedAt)}
                     </td>
-                    {form?.questions
-                      .slice()
-                      .sort((a, b) => a.order - b.order)
-                      .map((q) => (
-                        <td
-                          key={q.id}
-                          className="px-4 py-3 max-w-[200px] truncate"
-                          title={getAnswerValue(row.answers, q.id)}
-                        >
-                          {getAnswerValue(row.answers, q.id)}
-                        </td>
-                      ))}
+                    {orderedQuestions.map((q) => (
+                      <td
+                        key={q.id}
+                        className="px-4 py-3 max-w-[200px] truncate"
+                        title={getAnswerValue(row.answers, q.id)}
+                      >
+                        {getAnswerValue(row.answers, q.id)}
+                      </td>
+                    ))}
                   </tr>
                 ))}
               </tbody>
@@ -134,25 +218,25 @@ export default function FormResponsesPage() {
           </div>
         )}
 
-        {totalPages > 1 && (
+        {data && data.total > PAGE_SIZE && (
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-              Página {currentPage} de {totalPages}
+              Página {page} de {totalPages}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={offset === 0}
-                onClick={() => load(Math.max(0, offset - DEFAULT_LIMIT))}
+                disabled={page === 1 || loading}
+                onClick={() => handlePage(page - 1)}
               >
                 Anterior
               </Button>
               <Button
                 variant="outline"
                 size="sm"
-                disabled={offset + DEFAULT_LIMIT >= (data?.total ?? 0)}
-                onClick={() => load(offset + DEFAULT_LIMIT)}
+                disabled={page === totalPages || loading}
+                onClick={() => handlePage(page + 1)}
               >
                 Próxima
               </Button>

--- a/formix-frontend/src/app/(app)/forms/page.tsx
+++ b/formix-frontend/src/app/(app)/forms/page.tsx
@@ -57,7 +57,7 @@ export default function FormsPage() {
   return (
     <PageContainer>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-slate-900">Formulários</h1>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Formulários</h1>
         <Button onClick={handleCreate} className="bg-violet-600 hover:bg-violet-700">
           Criar formulário
         </Button>
@@ -71,7 +71,7 @@ export default function FormsPage() {
             className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
               statusFilter === option.value
                 ? 'bg-violet-600 text-white'
-                : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                : 'bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700'
             }`}
           >
             {option.label}
@@ -84,16 +84,16 @@ export default function FormsPage() {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-xl border bg-card shadow-sm h-48 animate-pulse bg-slate-100"
+              className="rounded-xl border bg-card shadow-sm h-48 animate-pulse bg-slate-100 dark:bg-slate-800"
             />
           ))}
         </div>
       ) : forms.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20 text-center">
-          <div className="rounded-full bg-violet-100 p-5 mb-4">
+          <div className="rounded-full bg-violet-100 dark:bg-violet-900/30 p-5 mb-4">
             <FileText className="size-10 text-violet-500" />
           </div>
-          <h2 className="text-lg font-semibold text-slate-800 mb-2">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-200 mb-2">
             {statusFilter ? 'Nenhum formulário encontrado' : 'Nenhum formulário ainda'}
           </h2>
           <p className="text-sm text-muted-foreground max-w-xs mb-6">

--- a/formix-frontend/src/app/(app)/settings/members/page.tsx
+++ b/formix-frontend/src/app/(app)/settings/members/page.tsx
@@ -74,7 +74,7 @@ export default function MembersPage() {
   return (
     <PageContainer>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-slate-900">Membros</h1>
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Membros</h1>
       </div>
 
       {members.length === 0 ? (

--- a/formix-frontend/src/app/(app)/settings/profile/page.tsx
+++ b/formix-frontend/src/app/(app)/settings/profile/page.tsx
@@ -71,7 +71,7 @@ export default function ProfilePage() {
 
   return (
     <PageContainer>
-      <h1 className="text-2xl font-bold text-slate-900 mb-6">Perfil</h1>
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mb-6">Perfil</h1>
 
       <div className="space-y-6 max-w-xl">
         <Card>

--- a/formix-frontend/src/app/(auth)/invite/page.tsx
+++ b/formix-frontend/src/app/(auth)/invite/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, Suspense } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { acceptInvitation } from '@/services/invitations/invitations.service';
 import { setAccessToken, setRefreshToken } from '@/services/auth-token';
@@ -14,7 +14,6 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 type PageState = 'loading' | 'error' | 'existing-user' | 'new-user' | 'needs-credentials';
 
 function InvitePageContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get('token');
 
@@ -39,7 +38,7 @@ function InvitePageContent() {
         const result = await acceptInvitation(token!);
         setAccessToken(result.accessToken);
         setRefreshToken(result.refreshToken);
-        router.push('/forms');
+        window.location.href = '/forms';
       } catch (err) {
         if (err instanceof ApiError) {
           if (err.statusCode === 400 && err.message?.includes('Name and password are required')) {
@@ -58,7 +57,7 @@ function InvitePageContent() {
     }
 
     tryAcceptAsExistingUser();
-  }, [token, router]);
+  }, [token]);
 
   async function handleAccept() {
     if (!token) return;
@@ -68,7 +67,7 @@ function InvitePageContent() {
       const result = await acceptInvitation(token);
       setAccessToken(result.accessToken);
       setRefreshToken(result.refreshToken);
-      router.push('/forms');
+      window.location.href = '/forms';
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.statusCode === 400 && err.message?.includes('Name and password are required')) {
@@ -97,8 +96,8 @@ function InvitePageContent() {
       setFormError('Nome é obrigatório.');
       return;
     }
-    if (password.length < 6) {
-      setFormError('A senha deve ter pelo menos 6 caracteres.');
+    if (password.length < 8) {
+      setFormError('A senha deve ter pelo menos 8 caracteres.');
       return;
     }
     if (password !== confirmPassword) {
@@ -111,7 +110,7 @@ function InvitePageContent() {
       const result = await acceptInvitation(token, { name: name.trim(), password });
       setAccessToken(result.accessToken);
       setRefreshToken(result.refreshToken);
-      router.push('/forms');
+      window.location.href = '/forms';
     } catch (err) {
       if (err instanceof ApiError && err.statusCode === 400) {
         setFormError('Convite inválido ou expirado.');
@@ -183,7 +182,7 @@ function InvitePageContent() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 disabled={loading}
-                placeholder="Mínimo 6 caracteres"
+                placeholder="Mínimo 8 caracteres"
                 autoComplete="new-password"
                 aria-required="true"
               />

--- a/formix-frontend/src/app/(auth)/layout.tsx
+++ b/formix-frontend/src/app/(auth)/layout.tsx
@@ -1,10 +1,15 @@
+import { ThemeToggle } from '@/components/ThemeToggle';
+
 interface AuthLayoutProps {
   children: React.ReactNode;
 }
 
 export default function AuthLayout({ children }: AuthLayoutProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-12">
+    <div className="min-h-screen flex items-center justify-center bg-muted/40 px-4 py-12">
+      <div className="fixed top-4 right-4">
+        <ThemeToggle />
+      </div>
       {children}
     </div>
   );

--- a/formix-frontend/src/app/(auth)/login/page.tsx
+++ b/formix-frontend/src/app/(auth)/login/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { login } from '@/services/auth/auth.service';
 import { setAccessToken, setRefreshToken } from '@/services/auth-token';
@@ -12,7 +11,6 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
 export default function LoginPage() {
-  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -39,7 +37,7 @@ export default function LoginPage() {
       const response = await login(email, password);
       setAccessToken(response.accessToken);
       setRefreshToken(response.refreshToken);
-      router.push('/forms');
+      window.location.href = '/forms';
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.statusCode === 403) {

--- a/formix-frontend/src/app/(public)/f/[publicToken]/page.tsx
+++ b/formix-frontend/src/app/(public)/f/[publicToken]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
+import axios from 'axios';
 import { getPublicForm, submitResponse } from '@/services/responses/responses.service';
 import type { PublicForm, Answer } from '@/services/responses/responses.types';
 import { QuestionRenderer } from '@/modules/QuestionRenderer/QuestionRenderer';
@@ -97,10 +98,8 @@ export default function PublicFormPage() {
       setState('success');
     } catch (err: unknown) {
       setState('form');
-      const status = (err as { response?: { status?: number; data?: { message?: string } } })
-        ?.response?.status;
-      const msg = (err as { response?: { data?: { message?: string } } })?.response?.data
-        ?.message;
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      const msg = axios.isAxiosError(err) ? err.response?.data?.message : undefined;
       if (status === 409) {
         setSubmitError('Você já respondeu este formulário.');
       } else if (status === 403) {

--- a/formix-frontend/src/app/globals.css
+++ b/formix-frontend/src/app/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Enable class-based dark mode for Tailwind v4 */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --color-background: #ffffff;
   --color-foreground: #0f172a;
@@ -52,7 +55,7 @@
   }
 }
 
-/* shadcn/ui CSS variable compatibility layer */
+/* shadcn/ui CSS variable compatibility layer — light */
 :root {
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;
@@ -74,4 +77,47 @@
   --input: 214.3 31.8% 91.4%;
   --ring: 245 58% 61%;
   --radius: 0.5rem;
+}
+
+/* shadcn/ui CSS variable compatibility layer — dark */
+.dark {
+  /* Tailwind theme overrides */
+  --color-background: #0f172a;
+  --color-foreground: #f8fafc;
+  --color-primary: #818cf8;
+  --color-primary-foreground: #1e1b4b;
+  --color-secondary: #1e293b;
+  --color-secondary-foreground: #f8fafc;
+  --color-muted: #1e293b;
+  --color-muted-foreground: #94a3b8;
+  --color-accent: #1e293b;
+  --color-accent-foreground: #f8fafc;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #ffffff;
+  --color-card: #1e293b;
+  --color-card-foreground: #f8fafc;
+  --color-border: #334155;
+  --color-input: #334155;
+  --color-ring: #818cf8;
+
+  /* shadcn/ui HSL overrides */
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 217.2 32.6% 12%;
+  --card-foreground: 210 40% 98%;
+  --popover: 217.2 32.6% 12%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 239 84% 67%;
+  --primary-foreground: 240 100% 14%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 217.2 32.6% 25%;
+  --input: 217.2 32.6% 25%;
+  --ring: 239 84% 67%;
 }

--- a/formix-frontend/src/app/layout.tsx
+++ b/formix-frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { ThemeProvider } from '@/components/ThemeProvider';
 import './globals.css';
 
 const geistSans = Geist({
@@ -23,9 +24,11 @@ interface RootLayoutProps {
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
-    <html lang="pt-BR">
+    <html lang="pt-BR" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
-        {children}
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/formix-frontend/src/app/page.tsx
+++ b/formix-frontend/src/app/page.tsx
@@ -1,25 +1,30 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ArrowRight, FileText, BarChart3, Shield } from 'lucide-react';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen bg-background">
+      <div className="fixed top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
+
       {/* Hero */}
-      <section className="bg-gradient-to-br from-violet-50 via-white to-indigo-50 px-4 py-24 text-center">
+      <section className="bg-gradient-to-br from-violet-50 via-background to-indigo-50 dark:from-slate-950 dark:via-background dark:to-slate-950 px-4 py-24 text-center">
         <div className="mx-auto max-w-3xl">
-          <div className="inline-block rounded-full bg-violet-100 px-4 py-1 text-sm font-medium text-violet-700 mb-6">
+          <div className="inline-block rounded-full bg-violet-100 dark:bg-violet-950 px-4 py-1 text-sm font-medium text-violet-700 dark:text-violet-300 mb-6">
             SaaS multi-tenant para formulários
           </div>
-          <h1 className="text-5xl font-extrabold text-slate-900 mb-6 tracking-tight">
+          <h1 className="text-5xl font-extrabold text-foreground mb-6 tracking-tight">
             Crie formulários.{' '}
-            <span className="text-violet-600">Colete respostas.</span>
+            <span className="text-violet-600 dark:text-violet-400">Colete respostas.</span>
           </h1>
-          <p className="text-lg text-slate-600 mb-10 max-w-xl mx-auto">
+          <p className="text-lg text-muted-foreground mb-10 max-w-xl mx-auto">
             Formix permite sua equipe criar formulários personalizados, compartilhar links e visualizar analytics — tudo com privacidade garantida.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <Button asChild size="lg" className="bg-violet-600 hover:bg-violet-700">
+            <Button asChild size="lg" className="bg-violet-600 hover:bg-violet-700 dark:bg-violet-600 dark:hover:bg-violet-500">
               <Link href="/signup">
                 Começar grátis <ArrowRight className="size-4" />
               </Link>
@@ -32,39 +37,39 @@ export default function Home() {
       </section>
 
       {/* Features */}
-      <section className="px-4 py-20 bg-white">
+      <section className="px-4 py-20 bg-background">
         <div className="mx-auto max-w-4xl">
-          <h2 className="text-3xl font-bold text-center text-slate-900 mb-12">
+          <h2 className="text-3xl font-bold text-center text-foreground mb-12">
             Tudo que você precisa
           </h2>
           <div className="grid md:grid-cols-3 gap-8">
-            <div className="text-center p-6 rounded-xl border border-slate-100 hover:border-violet-200 hover:shadow-sm transition-all">
-              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 p-3 mb-4">
-                <FileText className="size-6 text-violet-600" />
+            <div className="text-center p-6 rounded-xl border border-border hover:border-violet-300 dark:hover:border-violet-700 hover:shadow-sm transition-all">
+              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 dark:bg-violet-950 p-3 mb-4">
+                <FileText className="size-6 text-violet-600 dark:text-violet-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 mb-2">Formulários customizáveis</h3>
-              <p className="text-sm text-slate-500">Crie formulários com múltiplos tipos de pergunta adaptados ao seu negócio.</p>
+              <h3 className="font-semibold text-foreground mb-2">Formulários customizáveis</h3>
+              <p className="text-sm text-muted-foreground">Crie formulários com múltiplos tipos de pergunta adaptados ao seu negócio.</p>
             </div>
-            <div className="text-center p-6 rounded-xl border border-slate-100 hover:border-violet-200 hover:shadow-sm transition-all">
-              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 p-3 mb-4">
-                <Shield className="size-6 text-violet-600" />
+            <div className="text-center p-6 rounded-xl border border-border hover:border-violet-300 dark:hover:border-violet-700 hover:shadow-sm transition-all">
+              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 dark:bg-violet-950 p-3 mb-4">
+                <Shield className="size-6 text-violet-600 dark:text-violet-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 mb-2">Respostas anônimas</h3>
-              <p className="text-sm text-slate-500">Proteja a privacidade dos respondentes com total anonimato nas respostas.</p>
+              <h3 className="font-semibold text-foreground mb-2">Respostas anônimas</h3>
+              <p className="text-sm text-muted-foreground">Proteja a privacidade dos respondentes com total anonimato nas respostas.</p>
             </div>
-            <div className="text-center p-6 rounded-xl border border-slate-100 hover:border-violet-200 hover:shadow-sm transition-all">
-              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 p-3 mb-4">
-                <BarChart3 className="size-6 text-violet-600" />
+            <div className="text-center p-6 rounded-xl border border-border hover:border-violet-300 dark:hover:border-violet-700 hover:shadow-sm transition-all">
+              <div className="inline-flex items-center justify-center rounded-full bg-violet-100 dark:bg-violet-950 p-3 mb-4">
+                <BarChart3 className="size-6 text-violet-600 dark:text-violet-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 mb-2">Analytics em tempo real</h3>
-              <p className="text-sm text-slate-500">Dashboards detalhados para visualizar e analisar as respostas coletadas.</p>
+              <h3 className="font-semibold text-foreground mb-2">Analytics em tempo real</h3>
+              <p className="text-sm text-muted-foreground">Dashboards detalhados para visualizar e analisar as respostas coletadas.</p>
             </div>
           </div>
         </div>
       </section>
 
       {/* Footer CTA */}
-      <section className="bg-violet-600 px-4 py-16 text-center text-white">
+      <section className="bg-violet-600 dark:bg-violet-800 px-4 py-16 text-center text-white">
         <h2 className="text-3xl font-bold mb-4">Pronto para começar?</h2>
         <p className="text-violet-200 mb-8 max-w-md mx-auto">
           Junte-se à sua equipe e crie formulários profissionais em minutos.

--- a/formix-frontend/src/components/Layout/Header.tsx
+++ b/formix-frontend/src/components/Layout/Header.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
+import { ThemeToggle } from '@/components/ThemeToggle';
 import { Menu } from 'lucide-react';
 
 interface HeaderProps {
@@ -18,7 +19,7 @@ export function Header({ orgName, userName, onMenuClick, onLogout }: HeaderProps
     : 'U';
 
   return (
-    <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-white px-4 shadow-sm">
+    <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 shadow-sm">
       <button
         className="md:hidden p-2 rounded-md hover:bg-accent transition-colors"
         onClick={onMenuClick}
@@ -28,22 +29,25 @@ export function Header({ orgName, userName, onMenuClick, onLogout }: HeaderProps
         <Menu className="size-5" />
       </button>
 
-      <span className="font-semibold text-slate-800 hidden md:block">
+      <span className="font-semibold text-foreground hidden md:block">
         {orgName ?? 'Organização'}
       </span>
 
       <div className="flex-1" />
 
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
+        <ThemeToggle />
+
         {userName && (
           <>
+            <Separator orientation="vertical" className="h-5" />
             <div className="flex items-center gap-2">
               <Avatar className="size-8">
-                <AvatarFallback className="bg-violet-100 text-violet-700 text-xs font-semibold">
+                <AvatarFallback className="bg-violet-100 text-violet-700 text-xs font-semibold dark:bg-violet-900 dark:text-violet-300">
                   {initials}
                 </AvatarFallback>
               </Avatar>
-              <span className="text-sm text-slate-700 hidden sm:block">{userName}</span>
+              <span className="text-sm text-muted-foreground hidden sm:block">{userName}</span>
             </div>
             <Separator orientation="vertical" className="h-5" />
           </>

--- a/formix-frontend/src/components/Layout/Sidebar.tsx
+++ b/formix-frontend/src/components/Layout/Sidebar.tsx
@@ -29,17 +29,17 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       )}
       <nav
         className={`
-          fixed inset-y-0 left-0 z-50 w-64 bg-slate-950 text-slate-100 flex flex-col
+          fixed inset-y-0 left-0 z-50 w-64 bg-secondary text-secondary-foreground flex flex-col
           transform transition-transform duration-200 ease-in-out
           md:relative md:translate-x-0 md:z-auto md:flex md:min-h-0
           ${isOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
         aria-label="Navegação principal"
       >
-        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-800">
-          <span className="text-xl font-bold text-white tracking-tight">Formix</span>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <span className="text-xl font-bold text-foreground tracking-tight">Formix</span>
           <button
-            className="md:hidden p-1 rounded hover:bg-slate-800 transition-colors"
+            className="md:hidden p-1 rounded hover:bg-accent transition-colors"
             onClick={onClose}
             aria-label="Fechar menu"
           >
@@ -57,8 +57,8 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
                   className={`
                     flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors
                     ${isActive
-                      ? 'bg-violet-600/20 text-violet-300'
-                      : 'text-slate-400 hover:bg-slate-800 hover:text-slate-100'
+                      ? 'bg-primary/20 text-primary'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                     }
                   `}
                   aria-current={isActive ? 'page' : undefined}

--- a/formix-frontend/src/components/ThemeProvider.tsx
+++ b/formix-frontend/src/components/ThemeProvider.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/formix-frontend/src/components/ThemeToggle.tsx
+++ b/formix-frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { Sun, Moon } from 'lucide-react';
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return <div className="size-9" />;
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+      aria-label={isDark ? 'Ativar modo claro' : 'Ativar modo escuro'}
+    >
+      {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+    </button>
+  );
+}

--- a/formix-frontend/src/components/inputs/Checkbox/Checkbox.module.css
+++ b/formix-frontend/src/components/inputs/Checkbox/Checkbox.module.css
@@ -7,11 +7,11 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
@@ -27,19 +27,19 @@
   gap: 8px;
   cursor: pointer;
   font-size: 0.9375rem;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .checkbox {
   width: 18px;
   height: 18px;
-  accent-color: #7c6af7;
+  accent-color: var(--color-primary);
   cursor: pointer;
   flex-shrink: 0;
 }
 
 .checkbox:focus-visible {
-  outline: 2px solid #7c6af7;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -49,5 +49,5 @@
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/DatePicker/DatePicker.module.css
+++ b/formix-frontend/src/components/inputs/DatePicker/DatePicker.module.css
@@ -7,46 +7,46 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
 .input {
   height: 38px;
   padding: 0 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.9375rem;
-  color: #111827;
-  background: #fff;
+  color: var(--color-foreground);
+  background: var(--color-background);
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .input:focus-visible {
-  border-color: #7c6af7;
-  box-shadow: 0 0 0 3px rgba(124, 106, 247, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .inputError {
-  border-color: #ef4444;
+  border-color: var(--color-error);
 }
 
 .inputError:focus-visible {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .input:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   cursor: not-allowed;
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/Dropdown/Dropdown.module.css
+++ b/formix-frontend/src/components/inputs/Dropdown/Dropdown.module.css
@@ -7,47 +7,47 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
 .select {
   height: 38px;
   padding: 0 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.9375rem;
-  color: #111827;
-  background: #fff;
+  color: var(--color-foreground);
+  background: var(--color-background);
   outline: none;
   cursor: pointer;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .select:focus-visible {
-  border-color: #7c6af7;
-  box-shadow: 0 0 0 3px rgba(124, 106, 247, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .selectError {
-  border-color: #ef4444;
+  border-color: var(--color-error);
 }
 
 .selectError:focus-visible {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .select:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   cursor: not-allowed;
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/EmailInput/EmailInput.module.css
+++ b/formix-frontend/src/components/inputs/EmailInput/EmailInput.module.css
@@ -7,46 +7,46 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
 .input {
   height: 38px;
   padding: 0 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.9375rem;
-  color: #111827;
-  background: #fff;
+  color: var(--color-foreground);
+  background: var(--color-background);
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .input:focus-visible {
-  border-color: #7c6af7;
-  box-shadow: 0 0 0 3px rgba(124, 106, 247, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .inputError {
-  border-color: #ef4444;
+  border-color: var(--color-error);
 }
 
 .inputError:focus-visible {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .input:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   cursor: not-allowed;
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/FileUpload/FileUpload.module.css
+++ b/formix-frontend/src/components/inputs/FileUpload/FileUpload.module.css
@@ -7,11 +7,11 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
@@ -19,11 +19,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px dashed #d1d5db;
+  border: 2px dashed var(--color-border);
   border-radius: 8px;
   padding: 24px;
-  background: #f9fafb;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   font-size: 0.9375rem;
   text-align: center;
   min-height: 80px;
@@ -31,5 +31,5 @@
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/NumberInput/NumberInput.module.css
+++ b/formix-frontend/src/components/inputs/NumberInput/NumberInput.module.css
@@ -7,46 +7,46 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
 .input {
   height: 38px;
   padding: 0 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.9375rem;
-  color: #111827;
-  background: #fff;
+  color: var(--color-foreground);
+  background: var(--color-background);
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .input:focus-visible {
-  border-color: #7c6af7;
-  box-shadow: 0 0 0 3px rgba(124, 106, 247, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .inputError {
-  border-color: #ef4444;
+  border-color: var(--color-error);
 }
 
 .inputError:focus-visible {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .input:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   cursor: not-allowed;
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/RadioGroup/RadioGroup.module.css
+++ b/formix-frontend/src/components/inputs/RadioGroup/RadioGroup.module.css
@@ -7,11 +7,11 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
@@ -27,18 +27,18 @@
   gap: 8px;
   cursor: pointer;
   font-size: 0.9375rem;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .radio {
   width: 18px;
   height: 18px;
-  accent-color: #7c6af7;
+  accent-color: var(--color-primary);
   cursor: pointer;
 }
 
 .radio:focus-visible {
-  outline: 2px solid #7c6af7;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -48,5 +48,5 @@
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/RatingInput/RatingInput.module.css
+++ b/formix-frontend/src/components/inputs/RatingInput/RatingInput.module.css
@@ -7,11 +7,11 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
@@ -27,7 +27,7 @@
   cursor: pointer;
   font-size: 1.5rem;
   line-height: 1;
-  color: #d1d5db;
+  color: var(--color-muted-foreground);
   transition: color 0.1s;
   border-radius: 4px;
 }
@@ -38,7 +38,7 @@
 }
 
 .star:focus-visible {
-  outline: 2px solid #7c6af7;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -49,5 +49,5 @@
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/TextArea/TextArea.module.css
+++ b/formix-frontend/src/components/inputs/TextArea/TextArea.module.css
@@ -7,21 +7,21 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
 .textarea {
   padding: 8px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.9375rem;
-  color: #111827;
-  background: #fff;
+  color: var(--color-foreground);
+  background: var(--color-background);
   outline: none;
   resize: vertical;
   min-height: 80px;
@@ -30,25 +30,25 @@
 }
 
 .textarea:focus-visible {
-  border-color: #7c6af7;
-  box-shadow: 0 0 0 3px rgba(124, 106, 247, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .textareaError {
-  border-color: #ef4444;
+  border-color: var(--color-error);
 }
 
 .textareaError:focus-visible {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .textarea:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
+  background: var(--color-muted);
+  color: var(--color-muted-foreground);
   cursor: not-allowed;
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/components/inputs/Toggle/Toggle.module.css
+++ b/formix-frontend/src/components/inputs/Toggle/Toggle.module.css
@@ -7,11 +7,11 @@
 .label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .required {
-  color: #ef4444;
+  color: var(--color-error);
   margin-left: 2px;
 }
 
@@ -39,7 +39,7 @@
 .track {
   position: absolute;
   inset: 0;
-  background: #d1d5db;
+  background: var(--color-border);
   border-radius: 24px;
   transition: background 0.2s;
   cursor: pointer;
@@ -59,7 +59,7 @@
 }
 
 .input:checked + .track {
-  background: #7c6af7;
+  background: var(--color-primary);
 }
 
 .input:checked + .track::after {
@@ -67,7 +67,7 @@
 }
 
 .input:focus-visible + .track {
-  outline: 2px solid #7c6af7;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -78,10 +78,10 @@
 
 .switchLabel {
   font-size: 0.9375rem;
-  color: #374151;
+  color: var(--color-foreground);
 }
 
 .errorMsg {
   font-size: 0.8125rem;
-  color: #ef4444;
+  color: var(--color-error);
 }

--- a/formix-frontend/src/hooks/useAuth.ts
+++ b/formix-frontend/src/hooks/useAuth.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { getAccessToken, clearTokens } from '@/services/auth-token';
 import { httpClient } from '@/services/http-client';
 import type { AuthUser, AuthState } from '@/types/auth.types';
@@ -17,7 +16,6 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
 }
 
 export function useAuth(): AuthState & { logout: () => Promise<void> } {
-  const router = useRouter();
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -51,7 +49,7 @@ export function useAuth(): AuthState & { logout: () => Promise<void> } {
       // ignore logout errors — clear tokens regardless
     }
     clearTokens();
-    router.push('/login');
+    window.location.href = '/login';
   }
 
   return {

--- a/formix-frontend/src/hooks/useFormBuilder.ts
+++ b/formix-frontend/src/hooks/useFormBuilder.ts
@@ -7,6 +7,7 @@ import {
   updateForm,
   publishForm as publishFormService,
   closeForm as closeFormService,
+  expireForm as expireFormService,
   addQuestion as addQuestionService,
   updateQuestion as updateQuestionService,
   removeQuestion as removeQuestionService,
@@ -37,6 +38,7 @@ export function useFormBuilder(formId?: string) {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [isDirty, setIsDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(!!formId);
+  const [publicToken, setPublicToken] = useState<string | null>(null);
   const isFirstRender = useRef(true);
 
   useEffect(() => {
@@ -50,6 +52,7 @@ export function useFormBuilder(formId?: string) {
           settings: form.settings,
         });
         setQuestions(form.questions.slice().sort((a, b) => a.order - b.order));
+        setPublicToken(form.publicToken ?? null);
         isFirstRender.current = false;
       })
       .catch((err) => {
@@ -91,18 +94,22 @@ export function useFormBuilder(formId?: string) {
   }, [currentFormId, formData]);
 
   const addQuestion = useCallback(
-    async (type: QuestionType) => {
+    async (type: QuestionType): Promise<{ formId: string }> => {
       let fId = currentFormId;
       if (!fId) {
         fId = await saveForm();
       }
 
       const order = questions.length;
+      const typesWithOptions = ['checkbox', 'radio', 'dropdown'];
+      const defaultOptions = typesWithOptions.includes(type) ? ['Opção 1'] : undefined;
+
       const { questionId } = await addQuestionService(fId, {
         type,
-        label: '',
+        label: 'Nova pergunta',
         required: false,
         order,
+        options: defaultOptions,
       });
 
       const newQuestion: Question = {
@@ -110,13 +117,16 @@ export function useFormBuilder(formId?: string) {
         formId: fId,
         organizationId: '',
         type,
-        label: '',
+        label: 'Nova pergunta',
         required: false,
         order,
+        options: defaultOptions,
         createdAt: new Date().toISOString(),
       };
 
       setQuestions((prev) => [...prev, newQuestion]);
+      setIsDirty(true);
+      return { formId: fId };
     },
     [currentFormId, questions.length, saveForm],
   );
@@ -154,12 +164,20 @@ export function useFormBuilder(formId?: string) {
 
   const publishForm = useCallback(async () => {
     if (!currentFormId) throw new Error('Formulário não salvo');
-    return publishFormService(currentFormId);
+    const result = await publishFormService(currentFormId);
+    setPublicToken(result.publicToken);
+    return result;
   }, [currentFormId]);
 
   const closeForm = useCallback(async () => {
     if (!currentFormId) throw new Error('Formulário não salvo');
     return closeFormService(currentFormId);
+  }, [currentFormId]);
+
+  const expireForm = useCallback(async () => {
+    if (!currentFormId) throw new Error('Formulário não salvo');
+    await expireFormService(currentFormId);
+    setPublicToken(null);
   }, [currentFormId]);
 
   // Mark not first render after initial load is done
@@ -176,6 +194,7 @@ export function useFormBuilder(formId?: string) {
     questions,
     isDirty,
     isLoading,
+    publicToken,
     addQuestion,
     updateQuestion,
     removeQuestion,
@@ -183,5 +202,6 @@ export function useFormBuilder(formId?: string) {
     saveForm,
     publishForm,
     closeForm,
+    expireForm,
   };
 }

--- a/formix-frontend/src/modules/FormBuilder/FormBuilder.tsx
+++ b/formix-frontend/src/modules/FormBuilder/FormBuilder.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { Plus, Save, Globe, X, Settings, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Save, Globe, X, Settings, ChevronDown, ChevronUp, Link2, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
@@ -17,33 +18,39 @@ interface FormBuilderProps {
 }
 
 export function FormBuilder({ formId }: FormBuilderProps) {
+  const router = useRouter();
   const {
+    formId: currentFormId,
     formData,
     setFormData,
     questions,
     isDirty,
     isLoading,
+    publicToken,
     addQuestion,
     updateQuestion,
     removeQuestion,
     reorderQuestions,
     saveForm,
     publishForm,
-    closeForm,
+    expireForm,
   } = useFormBuilder(formId);
 
   const [showTypeSelector, setShowTypeSelector] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
-  const [isClosing, setIsClosing] = useState(false);
+  const [isExpiring, setIsExpiring] = useState(false);
   const [isAddingQuestion, setIsAddingQuestion] = useState(false);
 
   async function handleSave() {
     setIsSaving(true);
     try {
-      await saveForm();
+      const savedId = await saveForm();
       toast.success('Formulário salvo com sucesso.');
+      if (!formId && savedId) {
+        router.replace(`/forms/${savedId}/edit`);
+      }
     } catch {
       toast.error('Erro ao salvar formulário.');
     } finally {
@@ -55,7 +62,9 @@ export function FormBuilder({ formId }: FormBuilderProps) {
     setIsPublishing(true);
     try {
       const result = await publishForm();
-      toast.success(`Formulário publicado! Token: ${result.publicToken}`);
+      const url = `${window.location.origin}/f/${result.publicToken}`;
+      toast.success('Formulário publicado! Link copiado para a área de transferência.');
+      navigator.clipboard.writeText(url).catch(() => {});
     } catch {
       toast.error('Erro ao publicar formulário.');
     } finally {
@@ -63,22 +72,35 @@ export function FormBuilder({ formId }: FormBuilderProps) {
     }
   }
 
-  async function handleClose() {
-    setIsClosing(true);
+  function handleCopyLink() {
+    if (!publicToken) return;
+    const url = `${window.location.origin}/f/${publicToken}`;
+    navigator.clipboard.writeText(url).then(() => {
+      toast.success('Link copiado!');
+    }).catch(() => {
+      toast.error('Erro ao copiar link.');
+    });
+  }
+
+  async function handleExpire() {
+    setIsExpiring(true);
     try {
-      await closeForm();
-      toast.success('Formulário encerrado.');
+      await expireForm();
+      toast.success('Formulário despublicado e respostas excluídas.');
     } catch {
-      toast.error('Erro ao encerrar formulário.');
+      toast.error('Erro ao expirar formulário.');
     } finally {
-      setIsClosing(false);
+      setIsExpiring(false);
     }
   }
 
   async function handleSelectType(type: QuestionType) {
     setIsAddingQuestion(true);
     try {
-      await addQuestion(type);
+      const { formId: savedFormId } = await addQuestion(type);
+      if (!formId && savedFormId) {
+        router.replace(`/forms/${savedFormId}/edit`);
+      }
     } catch {
       toast.error('Erro ao adicionar pergunta.');
     } finally {
@@ -128,13 +150,13 @@ export function FormBuilder({ formId }: FormBuilderProps) {
             value={formData.title}
             onChange={(e) => setFormData({ title: e.target.value })}
             placeholder="Título do formulário"
-            className="text-xl font-semibold border-0 border-b border-slate-200 rounded-none px-0 focus-visible:ring-0 focus-visible:border-violet-500 text-slate-900"
+            className="text-xl font-semibold border-0 border-b border-slate-200 dark:border-slate-700 rounded-none px-0 focus-visible:ring-0 focus-visible:border-violet-500 text-slate-900 dark:text-slate-100"
           />
           <Input
             value={formData.description}
             onChange={(e) => setFormData({ description: e.target.value })}
             placeholder="Descrição (opcional)"
-            className="border-0 border-b border-slate-200 rounded-none px-0 focus-visible:ring-0 focus-visible:border-violet-500 text-slate-600 text-sm"
+            className="border-0 border-b border-slate-200 dark:border-slate-700 rounded-none px-0 focus-visible:ring-0 focus-visible:border-violet-500 text-slate-600 dark:text-slate-400 text-sm"
           />
         </div>
 
@@ -143,14 +165,25 @@ export function FormBuilder({ formId }: FormBuilderProps) {
             variant="outline"
             size="sm"
             onClick={handleSave}
-            disabled={isSaving || (!isDirty && !!formId)}
+            disabled={isSaving || (!isDirty && !!currentFormId)}
           >
             <Save className="size-4 mr-1.5" />
             {isSaving ? 'Salvando...' : 'Salvar rascunho'}
           </Button>
 
-          {formId ? (
-            <>
+          {currentFormId ? (
+            publicToken ? (
+              <Button
+                size="sm"
+                onClick={handleExpire}
+                disabled={isExpiring}
+                className="text-red-600 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-950"
+                variant="outline"
+              >
+                <X className="size-4 mr-1.5" />
+                {isExpiring ? 'Encerrando...' : 'Encerrar'}
+              </Button>
+            ) : (
               <Button
                 size="sm"
                 onClick={handlePublish}
@@ -160,20 +193,27 @@ export function FormBuilder({ formId }: FormBuilderProps) {
                 <Globe className="size-4 mr-1.5" />
                 {isPublishing ? 'Publicando...' : 'Publicar'}
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleClose}
-                disabled={isClosing}
-                className="text-red-600 border-red-200 hover:bg-red-50"
-              >
-                <X className="size-4 mr-1.5" />
-                {isClosing ? 'Encerrando...' : 'Encerrar'}
-              </Button>
-            </>
+            )
           ) : null}
         </div>
       </div>
+
+      {publicToken && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 rounded-lg text-sm">
+          <Link2 className="size-4 text-violet-500 dark:text-violet-400 shrink-0" />
+          <span className="text-violet-700 dark:text-violet-300 font-medium truncate flex-1">
+            {`${typeof window !== 'undefined' ? window.location.origin : ''}/f/${publicToken}`}
+          </span>
+          <button
+            type="button"
+            onClick={handleCopyLink}
+            className="flex items-center gap-1 text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-200 shrink-0"
+          >
+            <Copy className="size-3.5" />
+            Copiar
+          </button>
+        </div>
+      )}
 
       <Separator />
 
@@ -190,7 +230,7 @@ export function FormBuilder({ formId }: FormBuilderProps) {
           variant="outline"
           onClick={() => setShowTypeSelector(true)}
           disabled={isAddingQuestion}
-          className="w-full border-dashed border-violet-300 text-violet-600 hover:bg-violet-50 hover:text-violet-700"
+          className="w-full border-dashed border-violet-300 dark:border-violet-700 text-violet-600 dark:text-violet-400 hover:bg-violet-50 hover:text-violet-700 dark:hover:bg-violet-950/30 dark:hover:text-violet-300"
         >
           <Plus className="size-4 mr-2" />
           {isAddingQuestion ? 'Adicionando...' : 'Adicionar pergunta'}
@@ -204,7 +244,7 @@ export function FormBuilder({ formId }: FormBuilderProps) {
         <button
           type="button"
           onClick={() => setShowSettings((v) => !v)}
-          className="flex items-center gap-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors"
+          className="flex items-center gap-2 text-sm font-medium text-slate-700 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100 transition-colors"
         >
           <Settings className="size-4" />
           Configurações do formulário
@@ -216,7 +256,7 @@ export function FormBuilder({ formId }: FormBuilderProps) {
         </button>
 
         {showSettings && (
-          <div className="mt-4 p-4 border border-slate-200 rounded-lg bg-slate-50">
+          <div className="mt-4 p-4 border border-slate-200 dark:border-slate-700 rounded-lg bg-slate-50 dark:bg-slate-800/50">
             <FormSettings
               settings={formData.settings}
               onChange={(partial) =>

--- a/formix-frontend/src/modules/FormBuilder/FormSettings.tsx
+++ b/formix-frontend/src/modules/FormBuilder/FormSettings.tsx
@@ -76,7 +76,7 @@ export function FormSettings({ settings, onChange }: FormSettingsProps) {
           {settings.allowedEmailDomains.map((domain) => (
             <span
               key={domain}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 text-violet-700 text-xs font-medium"
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 text-xs font-medium"
             >
               {domain}
               <button

--- a/formix-frontend/src/modules/FormBuilder/QuestionEditor.tsx
+++ b/formix-frontend/src/modules/FormBuilder/QuestionEditor.tsx
@@ -5,7 +5,9 @@ import { Trash2, Plus, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { QuestionRenderer } from '@/modules/QuestionRenderer/QuestionRenderer';
 import type { Question } from '@/services/forms/forms.types';
+import type { PublicFormQuestion } from '@/services/responses/responses.types';
 
 interface QuestionEditorProps {
   question: Question;
@@ -31,6 +33,7 @@ const typeLabels: Record<string, string> = {
 
 export function QuestionEditor({ question, onUpdate, onRemove }: QuestionEditorProps) {
   const [newOption, setNewOption] = useState('');
+  const [previewValue, setPreviewValue] = useState<unknown>(undefined);
   const hasOptions = typesWithOptions.includes(question.type);
   const options = question.options ?? [];
 
@@ -53,7 +56,7 @@ export function QuestionEditor({ question, onUpdate, onRemove }: QuestionEditorP
   }
 
   return (
-    <div className="space-y-4 p-4 border border-slate-200 rounded-lg bg-white">
+    <div className="space-y-4 p-4 border border-slate-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-900">
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 space-y-3">
           <div className="space-y-1">
@@ -143,8 +146,15 @@ export function QuestionEditor({ question, onUpdate, onRemove }: QuestionEditorP
         </div>
       )}
 
-      <div className="rounded-md bg-slate-50 border border-slate-200 px-3 py-2 text-xs text-slate-500">
-        Pré-visualização: [{typeLabels[question.type] ?? question.type}]
+      <div className="rounded-md bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-3 space-y-1.5">
+        <span className="text-xs text-slate-400 dark:text-slate-500 font-medium">Pré-visualização</span>
+        <div className="pointer-events-none opacity-80">
+          <QuestionRenderer
+            question={question as unknown as PublicFormQuestion}
+            value={previewValue}
+            onChange={setPreviewValue}
+          />
+        </div>
       </div>
     </div>
   );

--- a/formix-frontend/src/modules/FormBuilder/QuestionTypeSelector.tsx
+++ b/formix-frontend/src/modules/FormBuilder/QuestionTypeSelector.tsx
@@ -43,12 +43,12 @@ const questionTypes: QuestionTypeOption[] = [
 export function QuestionTypeSelector({ onSelect, onClose }: QuestionTypeSelectorProps) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-md">
+      <div className="bg-white dark:bg-slate-900 rounded-xl shadow-xl p-6 w-full max-w-md">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-base font-semibold text-slate-900">Escolha o tipo de pergunta</h3>
+          <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">Escolha o tipo de pergunta</h3>
           <button
             onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 text-xl leading-none"
+            className="text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 text-xl leading-none"
             aria-label="Fechar"
           >
             ×
@@ -62,7 +62,7 @@ export function QuestionTypeSelector({ onSelect, onClose }: QuestionTypeSelector
                 onSelect(type);
                 onClose();
               }}
-              className="flex flex-col items-center gap-2 p-3 rounded-lg border border-slate-200 hover:border-violet-400 hover:bg-violet-50 transition-colors text-slate-700 hover:text-violet-700"
+              className="flex flex-col items-center gap-2 p-3 rounded-lg border border-slate-200 dark:border-slate-700 hover:border-violet-400 dark:hover:border-violet-500 hover:bg-violet-50 dark:hover:bg-violet-950/30 transition-colors text-slate-700 dark:text-slate-300 hover:text-violet-700 dark:hover:text-violet-300"
             >
               {icon}
               <span className="text-xs font-medium text-center leading-tight">{label}</span>

--- a/formix-frontend/src/modules/FormCard/StatusBadge.tsx
+++ b/formix-frontend/src/modules/FormCard/StatusBadge.tsx
@@ -7,24 +7,24 @@ interface StatusBadgeProps {
 const statusConfig: Record<string, { label: string; className: string }> = {
   draft: {
     label: 'Rascunho',
-    className: 'bg-slate-100 text-slate-700',
+    className: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
   },
   active: {
     label: 'Ativo',
-    className: 'bg-green-100 text-green-700',
+    className: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
   },
   expired: {
     label: 'Expirado',
-    className: 'bg-amber-100 text-amber-700',
+    className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
   },
   closed: {
     label: 'Encerrado',
-    className: 'bg-red-100 text-red-700',
+    className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
   },
 };
 
 export function StatusBadge({ status }: StatusBadgeProps) {
-  const config = statusConfig[status] ?? { label: status, className: 'bg-slate-100 text-slate-700' };
+  const config = statusConfig[status] ?? { label: status, className: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' };
 
   return (
     <span

--- a/formix-frontend/src/modules/InvitationsSection/InvitationsSection.tsx
+++ b/formix-frontend/src/modules/InvitationsSection/InvitationsSection.tsx
@@ -93,7 +93,7 @@ export function InvitationsSection({ isAdmin }: InvitationsSectionProps) {
   return (
     <div className="mt-8">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-slate-900">Convites pendentes</h2>
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Convites pendentes</h2>
         <Button onClick={() => setShowInviteModal(true)}>Convidar membro</Button>
       </div>
 

--- a/formix-frontend/src/services/auth-token.ts
+++ b/formix-frontend/src/services/auth-token.ts
@@ -1,5 +1,14 @@
 const ACCESS_TOKEN_KEY = 'formix:access_token';
 const REFRESH_TOKEN_KEY = 'formix:refresh_token';
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+
+function setCookie(name: string, value: string): void {
+  document.cookie = `${name}=${value}; path=/; SameSite=Lax`;
+}
+
+function deleteCookie(name: string): void {
+  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
 
 export function getAccessToken(): string | null {
   if (typeof window === 'undefined') return null;
@@ -9,6 +18,7 @@ export function getAccessToken(): string | null {
 export function setAccessToken(token: string): void {
   if (typeof window === 'undefined') return;
   localStorage.setItem(ACCESS_TOKEN_KEY, token);
+  setCookie(ACCESS_TOKEN_COOKIE, token);
 }
 
 export function getRefreshToken(): string | null {
@@ -25,4 +35,5 @@ export function clearTokens(): void {
   if (typeof window === 'undefined') return;
   localStorage.removeItem(ACCESS_TOKEN_KEY);
   localStorage.removeItem(REFRESH_TOKEN_KEY);
+  deleteCookie(ACCESS_TOKEN_COOKIE);
 }

--- a/formix-frontend/src/services/forms/forms.service.ts
+++ b/formix-frontend/src/services/forms/forms.service.ts
@@ -8,8 +8,8 @@ export async function listForms(status?: string): Promise<FormSummary[]> {
 }
 
 export async function getForm(id: string): Promise<FormDetail> {
-  const response = await httpClient.get<FormDetail>(`/forms/${id}`);
-  return response.data;
+  const response = await httpClient.get<{ form: Omit<FormDetail, 'questions'>; questions: FormDetail['questions'] }>(`/forms/${id}`);
+  return { ...response.data.form, questions: response.data.questions };
 }
 
 export async function createForm(data: CreateFormInput): Promise<{ formId: string }> {
@@ -34,6 +34,10 @@ export async function publishForm(id: string): Promise<{ publicToken: string; pu
 
 export async function closeForm(id: string): Promise<void> {
   await httpClient.post(`/forms/${id}/close`);
+}
+
+export async function expireForm(id: string): Promise<void> {
+  await httpClient.post(`/forms/${id}/expire`);
 }
 
 export async function addQuestion(

--- a/formix-frontend/src/services/http-client.ts
+++ b/formix-frontend/src/services/http-client.ts
@@ -46,9 +46,11 @@ httpClient.interceptors.response.use(
   async (error: AxiosError<{ message?: string; errors?: string[] }>) => {
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 
-    if (error.response?.status !== 401) {
+    if (error.response?.status !== 401 || originalRequest._retry) {
       return Promise.reject(ApiError.fromAxiosError(error));
     }
+
+    originalRequest._retry = true;
 
     const refreshToken = getRefreshToken();
     if (!refreshToken) {
@@ -87,6 +89,9 @@ httpClient.interceptors.response.use(
     } catch (refreshError) {
       clearTokens();
       processQueue(refreshError, null);
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
       return Promise.reject(refreshError);
     } finally {
       isRefreshing = false;

--- a/formix-frontend/src/services/responses/responses.service.ts
+++ b/formix-frontend/src/services/responses/responses.service.ts
@@ -30,10 +30,21 @@ export async function listResponses(
   formId: string,
   offset = 0,
   limit = 20,
+  search?: string,
+  sortBy?: string,
+  sortDir?: 'asc' | 'desc',
 ): Promise<ListResponsesOutput> {
   const response = await httpClient.get<ListResponsesOutput>(
     `/forms/${formId}/responses`,
-    { params: { offset, limit } },
+    {
+      params: {
+        offset,
+        limit,
+        ...(search && { search }),
+        ...(sortBy && { sortBy }),
+        ...(sortDir && { sortDir }),
+      },
+    },
   );
   return response.data;
 }


### PR DESCRIPTION
## Descrição

Conjunto de correções e melhorias que abordam bugs no módulo de autenticação, refatoram os repositórios de formulários e respostas com o padrão Mapper, adicionam a funcionalidade de expirar formulários e filtragem de respostas, implementam suporte a dark mode no frontend e corrigem o ciclo de refresh de token no cliente HTTP.

---

## Commits

### `8cc01c4` — feat(backend): add swagger setup and global validation pipe

Configuração global do Swagger em `main.ts` (título, versão, autenticação Bearer) e registro do `ValidationPipe` com `whitelist: true`. Garante que todos os endpoints passem a expor documentação na rota `/api/docs` e que inputs inválidos sejam rejeitados automaticamente antes de chegar aos use cases.

---

### `abdc163` — fix(auth): include name+email in jwt payload; return 403 on unconfirmed email

Os use cases `LoginUseCase` e `RefreshTokenUseCase` agora incluem `name` e `email` no payload do JWT, permitindo que o frontend leia esses dados diretamente do token sem chamadas adicionais. Corrigido o status HTTP de `400` para `403` quando o email do usuário ainda não foi confirmado, alinhando com a semântica REST correta.

---

### `546cd27` — refactor(forms): extract mappers and use lean queries in repositories

Criado `BidirectionalMapper<L, R>` em `shared/` como contrato para mappers de domínio. Extraídos `FormMapper` e `QuestionMapper` dos repositórios, tornando a lógica de conversão entre documento Mongo e entidade de domínio testável isoladamente. Os repositórios passaram a usar `.lean()` para evitar overhead de instâncias Mongoose e a lógica de upsert foi simplificada (create ou replace explícito). Adicionado método `unpublish()` ao `FormAggregate`.

---

### `09b6834` — feat(responses): add search/sort, expire-form endpoint and response mappers

Adicionados parâmetros `search`, `sortBy` e `sortDir` ao `IResponseRepository`, `ListResponsesUseCase` e ao controller `GET /forms/:id/responses`. Criado endpoint `POST /forms/:id/expire` com `ExpireFormUseCase` que despublica o formulário e apaga todas as respostas associadas. Extraídos `ResponseMapper` e `ResponseEmailMapper` seguindo o mesmo padrão da refatoração do módulo forms. Adicionado `@Allow()` no `AnswerDto.value` para permitir qualquer tipo com `ValidationPipe`.

---

### `a25aafe` — feat(email): add ethereal provider and shared html email templates

Criado novo provider `EtherealEmailService` (útil em desenvolvimento) e registrado no `EmailModule` via `EMAIL_PROVIDER=ethereal`. Templates de email HTML extraídos para `email-templates.ts` compartilhado entre os providers Mailtrap e Ethereal, eliminando duplicação. Templates incluem layout responsivo e estilização inline.

---

### `6c02fce` — feat(frontend): add dark mode support with ThemeProvider and ThemeToggle

Instalado `next-themes` e criados `ThemeProvider` e `ThemeToggle`. O `RootLayout` agora envolve a aplicação com `ThemeProvider`. Adicionadas variáveis CSS para o tema escuro em `globals.css`, incluindo overrides para os tokens do shadcn/ui e do Tailwind. Componentes de input, layout (Header, Sidebar) e páginas públicas receberam classes `dark:` para adaptação visual.

---

### `fb13adc` — fix(frontend): sync access token to cookie and fix http-client refresh loop

`auth-token.ts` passou a sincronizar o access token em um cookie (`accessToken`) além do `localStorage`, necessário para middlewares Next.js que precisam ler o token server-side. Corrigido loop infinito no interceptor de refresh do `http-client`: adicionado flag `_retry` para evitar que uma requisição refaça o ciclo de refresh indefinidamente. `useAuth` substituiu `router.push('/login')` por `window.location.href` para forçar reload completo ao deslogar.

---

### `2974707` — feat(frontend): add expire-form action, search/sort in responses, form builder improvements

`useFormBuilder` expõe `expireForm` e `publicToken` e inicializa perguntas de múltipla escolha com `['Opção 1']` por padrão. `FormBuilder` integra o botão de expirar formulário. A página de respostas ganhou barra de busca com debounce, cabeçalhos de coluna clicáveis para ordenação e indicadores visuais de direção. `listResponses` do serviço repassa os parâmetros `search`, `sortBy` e `sortDir` para a API. `getForm` foi corrigido para desempacotar a resposta `{ form, questions }` do backend.

---

### `7ac56d0` — chore: ignore .playwright-mcp directory

Adicionado `.playwright-mcp/` ao `.gitignore` para evitar que arquivos gerados pela integração Playwright MCP sejam rastreados.

---

## Checklist

- [ ] Todos os testes passando
- [ ] Sem arquivos de configuração sensíveis (.env, secrets)
- [ ] Import rules do DDD respeitadas (domain não importa infra)
- [ ] Swagger documentado em endpoints novos
- [ ] Isolamento por organizationId em queries MongoDB